### PR TITLE
Update BLOB documentation for of method and usage

### DIFF
--- a/docs/ja/blob.md
+++ b/docs/ja/blob.md
@@ -6,15 +6,14 @@ BLOBが格納するバイト列は符号なし8bit整数として管理されま
 
 ## `BLOB.of` 配列からのBLOBの生成
 
-`BLOB.of(array: STREAM<BLOB | ARRAY<NUMBER>>): BLOB`
+`BLOB.of(array: STREAM<NUMBER | ARRAY<NUMBER> | BLOB>): BLOB`
 
 `array` から新しいBLOBを生成します。
 
-`array` が配列の場合、各要素は数値からなる配列でなければならず、変換時に小数点以下の四捨五入と下位8ビット以外のビットの削除が行われます。
-
-`array` がBLOBの場合、そのまま新しいBLOBインスタンスにコピーされます。
-
-`array` がストリームの場合、各要素を結合したBLOBを生成します。
+- `array` が数値の場合、小数点以下の四捨五入と下位8ビット以外のビットの削除が行われた状態で新しいBLOBに追加されます。
+- `array` が配列の場合、各要素は数値として処理されます。
+- `array` がBLOBの場合、そのまま新しいBLOBインスタンスにコピーされます。
+- `array` がストリームの場合、各要素が上記の方法で新しいBLOBに追加されます。
 
 ```shell
 $ xa '

--- a/src/commonTest/kotlin/BlobTest.kt
+++ b/src/commonTest/kotlin/BlobTest.kt
@@ -23,6 +23,92 @@ class BlobTest {
     }
 
     @Test
+    fun ofFromNumber() = runTest {
+        // 数値が直接渡された場合：小数点以下の四捨五入と下位8ビット以外のビットの削除
+        assertEquals("123", (eval("BLOB.of(123)").blob)) // 整数
+        assertEquals("1", (eval("BLOB.of(1.4)").blob)) // 1.4 -> 1 (四捨五入)
+        assertEquals("2", (eval("BLOB.of(1.6)").blob)) // 1.6 -> 2 (四捨五入)
+        assertEquals("0", (eval("BLOB.of(256)").blob)) // 256で0にオーバーフローする
+        assertEquals("255", (eval("BLOB.of(-1)").blob)) // -1でも255にオーバーフローする
+        assertEquals("1", (eval("BLOB.of(257)").blob)) // 下位8ビットだけが使われる
+        assertEquals("0", (eval("BLOB.of(0)").blob)) // 0
+        assertEquals("255", (eval("BLOB.of(255)").blob)) // 255
+    }
+
+    @Test
+    fun ofFromBlob() = runTest {
+        assertEquals("1,2,3", (eval("BLOB.of(BLOB.of([1,2,3]))").blob)) // BLOBからの生成
+        assertEquals("", (eval("BLOB.of(BLOB.of([]))").blob)) // 空BLOBの場合
+        assertEquals("1", (eval("BLOB.of(BLOB.of([1]))").blob)) // 1要素のBLOB
+    }
+
+    @Test
+    fun ofFromStream() = runTest {
+        // ストリームから生成：複数の配列を結合
+        assertEquals("1,0,255,0,1,1,2", (eval("""
+            BLOB.of(
+                [1, 0, -1],
+                [256, 257],
+                [1.4, 1.6],
+            )
+        """).blob))
+
+        // ストリームから生成：BLOBと配列の混在
+        assertEquals("1,2,3,4,5", (eval("""
+            BLOB.of(
+                BLOB.of([1, 2]),
+                [3, 4, 5],
+            )
+        """).blob))
+
+        // ストリームから生成：空の要素を含む
+        assertEquals("1,2", (eval("""
+            BLOB.of(
+                [1],
+                [],
+                [2],
+            )
+        """).blob))
+
+        // ストリームから生成：全て空
+        assertEquals("", (eval("""
+            BLOB.of(
+                [],
+                [],
+            )
+        """).blob))
+
+        // ストリームから生成：数値、配列、BLOBの混在
+        assertEquals("10,20,30,40,50,60", (eval("""
+            BLOB.of(
+                10,
+                [20, 30],
+                BLOB.of([40, 50]),
+                60,
+            )
+        """).blob))
+
+        // ストリームから生成：数値のみ
+        assertEquals("1,2,3", (eval("""
+            BLOB.of(
+                1,
+                2,
+                3,
+            )
+        """).blob))
+
+        // ストリームから生成：数値と小数の混在（四捨五入確認）
+        assertEquals("1,2,2,4", (eval("""
+            BLOB.of(
+                1.4,
+                1.6,
+                2.4,
+                3.5,
+            )
+        """).blob))
+    }
+
+    @Test
     fun toArray() = runTest {
         assertEquals("[1;2;3]", (eval("BLOB.of([1,2,3])::toArray()").array())) // 配列への変換
         assertEquals("[]", (eval("BLOB.of([])::toArray()").array())) // 空の場合


### PR DESCRIPTION
Expanded and clarified the description of the BLOB type and its usage. Updated the documentation for the BLOB.of method to reflect support for arrays, BLOBs, and streams, and improved example usage for better clarity.