### PR TITLE
STRING に take / taker / drop / dropr / first / last メソッドを追加するのだ。

### DIFF
--- a/changelog.d/add-string-take-drop-methods.md
+++ b/changelog.d/add-string-take-drop-methods.md
@@ -1,0 +1,1 @@
+Added STRING methods `take`, `taker`, `drop`, `dropr`, `first`, and `last` (with the synonyms `takeFirst`, `takeLast`, `dropFirst`, and `dropLast`) for taking and dropping characters from the ends of a string.

--- a/changelog.d/add-string-take-drop-methods.md
+++ b/changelog.d/add-string-take-drop-methods.md
@@ -1,1 +1,2 @@
-Added STRING methods `take`, `taker`, `drop`, `dropr`, `first`, and `last` (with the synonyms `takeFirst`, `takeLast`, `dropFirst`, and `dropLast`) for taking and dropping characters from the ends of a string.
+Added STRING methods `take`, `taker`, `drop`, and `dropr` (with the synonyms `takeFirst`, `takeLast`, `dropFirst`, and `dropLast`) for taking and dropping characters from the ends of a string.
+Added STRING methods `first` and `last` that return the first or last character of a string, or `NULL` if the string is empty.

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -372,7 +372,7 @@ $ xa '"abcde"[1..3]'
 # bcd
 ```
 
-# Taking and Dropping from the Ends
+# Taking and Dropping Substrings from the Ends
 
 `STRING::take(count: INT): STRING`
 
@@ -382,39 +382,54 @@ $ xa '"abcde"[1..3]'
 
 `STRING::dropr(count: INT): STRING`
 
+Returns the string obtained by taking or dropping the first or last `count` characters of the string.
+
+`count` is converted to a number and rounded.
+
+Each method has an alias with identical behavior.
+
+| Method  | Alias       | Target | Operation | Behavior when `count` exceeds the string length |
+|---------|-------------|--------|-----------|-------------------------------------------------|
+| `take`  | `takeFirst` | First  | Take      | The entire string                               |
+| `taker` | `takeLast`  | Last   | Take      | The entire string                               |
+| `drop`  | `dropFirst` | First  | Drop      | An empty string                                 |
+| `dropr` | `dropLast`  | Last   | Drop      | An empty string                                 |
+
+```shell
+$ xa '"[" & "abcde"::take(2) & "]"'
+# [ab]
+
+$ xa '"[" & "abcde"::taker(2) & "]"'
+# [de]
+
+$ xa '"[" & "abcde"::take(0) & "]"'
+# []
+
+$ xa '"[" & "abcde"::take(10) & "]"'
+# [abcde]
+
+$ xa '"[" & "abcde"::drop(2) & "]"'
+# [cde]
+
+$ xa '"[" & "abcde"::dropr(2) & "]"'
+# [abc]
+
+$ xa '"[" & "abcde"::drop(0) & "]"'
+# [abcde]
+
+$ xa '"[" & "abcde"::drop(10) & "]"'
+# []
+```
+
+# Taking Characters from the Ends
+
 `STRING::first(): STRING | NULL`
 
 `STRING::last(): STRING | NULL`
 
-The `take` and `taker` methods get the first and last `count` characters, and the `drop` and `dropr` methods remove the first and last `count` characters.
+The `first` and `last` methods get the first or last single character.
 
-`count` is converted to a number and rounded. If `count` exceeds the length of the string, `take` and `taker` return the entire string, while `drop` and `dropr` return an empty string.
-
-```shell
-$ xa '"abcde"::take(2)'
-# ab
-
-$ xa '"abcde"::taker(2)'
-# de
-
-$ xa '"abcde"::drop(2)'
-# cde
-
-$ xa '"abcde"::dropr(2)'
-# abc
-```
-
-`takeFirst` is an alias of `take`, `takeLast` of `taker`, `dropFirst` of `drop`, and `dropLast` of `dropr`, each having identical behavior.
-
-```shell
-$ xa '"abcde"::takeLast(2)'
-# de
-
-$ xa '"abcde"::dropLast(2)'
-# abc
-```
-
-The `first` and `last` methods get the first and last single character. If the string is empty, `NULL` is returned.
+If the string is empty, `NULL` is returned.
 
 ```shell
 $ xa '"abcde"::first()'
@@ -422,6 +437,12 @@ $ xa '"abcde"::first()'
 
 $ xa '"abcde"::last()'
 # e
+
+$ xa '""::first()'
+# NULL
+
+$ xa '""::last()'
+# NULL
 ```
 
 # String Replacement

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -372,6 +372,58 @@ $ xa '"abcde"[1..3]'
 # bcd
 ```
 
+# Taking and Dropping from the Ends
+
+`STRING::take(count: INT): STRING`
+
+`STRING::taker(count: INT): STRING`
+
+`STRING::drop(count: INT): STRING`
+
+`STRING::dropr(count: INT): STRING`
+
+`STRING::first(): STRING | NULL`
+
+`STRING::last(): STRING | NULL`
+
+The `take` and `taker` methods get the first and last `count` characters, and the `drop` and `dropr` methods remove the first and last `count` characters.
+
+`count` is converted to a number and rounded. If `count` exceeds the length of the string, `take` and `taker` return the entire string, while `drop` and `dropr` return an empty string.
+
+```shell
+$ xa '"abcde"::take(2)'
+# ab
+
+$ xa '"abcde"::taker(2)'
+# de
+
+$ xa '"abcde"::drop(2)'
+# cde
+
+$ xa '"abcde"::dropr(2)'
+# abc
+```
+
+`takeFirst` is an alias of `take`, `takeLast` of `taker`, `dropFirst` of `drop`, and `dropLast` of `dropr`, each having identical behavior.
+
+```shell
+$ xa '"abcde"::takeLast(2)'
+# de
+
+$ xa '"abcde"::dropLast(2)'
+# abc
+```
+
+The `first` and `last` methods get the first and last single character. If the string is empty, `NULL` is returned.
+
+```shell
+$ xa '"abcde"::first()'
+# a
+
+$ xa '"abcde"::last()'
+# e
+```
+
 # String Replacement
 
 `STRING::replace(old: STRING | REGEX; new: STRING | (match: VALUE) -> STRING): STRING`

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -372,7 +372,7 @@ $ xa '"abcde"[1..3]'
 # bcd
 ```
 
-# 先頭・末尾の取得と除去
+# 先頭・末尾の部分文字列の取得と除去
 
 `STRING::take(count: INT): STRING`
 
@@ -382,39 +382,54 @@ $ xa '"abcde"[1..3]'
 
 `STRING::dropr(count: INT): STRING`
 
+文字列の先頭または末尾の、 `count` 文字を取得または除去した文字列を返します。
+
+`count` は数値化し、四捨五入されます。
+
+各メソッドには同一の動作を持つ別名が存在します。
+
+| メソッド    | 別名          | 対象 | 操作 | `count` が文字列の長さを超える場合の動作 |
+|---------|-------------|----|----|--------------------------|
+| `take`  | `takeFirst` | 先頭 | 取得 | 文字列全体                    |
+| `taker` | `takeLast`  | 末尾 | 取得 | 文字列全体                    |
+| `drop`  | `dropFirst` | 先頭 | 除去 | 空文字列                     |
+| `dropr` | `dropLast`  | 末尾 | 除去 | 空文字列                     |
+
+```shell
+$ xa '"[" & "abcde"::take(2) & "]"'
+# [ab]
+
+$ xa '"[" & "abcde"::taker(2) & "]"'
+# [de]
+
+$ xa '"[" & "abcde"::take(0) & "]"'
+# []
+
+$ xa '"[" & "abcde"::take(10) & "]"'
+# [abcde]
+
+$ xa '"[" & "abcde"::drop(2) & "]"'
+# [cde]
+
+$ xa '"[" & "abcde"::dropr(2) & "]"'
+# [abc]
+
+$ xa '"[" & "abcde"::drop(0) & "]"'
+# [abcde]
+
+$ xa '"[" & "abcde"::drop(10) & "]"'
+# []
+```
+
+# 先頭・末尾の文字の取得
+
 `STRING::first(): STRING | NULL`
 
 `STRING::last(): STRING | NULL`
 
-`take` `taker` メソッドで先頭・末尾の `count` 文字を取得し、 `drop` `dropr` メソッドで先頭・末尾の `count` 文字を除去できます。
+`first` `last` メソッドで先頭・末尾の1文字を取得します。
 
-`count` は数値化し、四捨五入されます。 `count` が文字列の長さを超える場合、 `take` `taker` は文字列全体を、 `drop` `dropr` は空文字列を返します。
-
-```shell
-$ xa '"abcde"::take(2)'
-# ab
-
-$ xa '"abcde"::taker(2)'
-# de
-
-$ xa '"abcde"::drop(2)'
-# cde
-
-$ xa '"abcde"::dropr(2)'
-# abc
-```
-
-`takeFirst` は `take` の、 `takeLast` は `taker` の、 `dropFirst` は `drop` の、 `dropLast` は `dropr` の別名であり、それぞれ同一の動作を持ちます。
-
-```shell
-$ xa '"abcde"::takeLast(2)'
-# de
-
-$ xa '"abcde"::dropLast(2)'
-# abc
-```
-
-`first` `last` メソッドで先頭・末尾の 1 文字を取得します。文字列が空の場合は `NULL` を返します。
+文字列が空の場合は `NULL` を返します。
 
 ```shell
 $ xa '"abcde"::first()'
@@ -422,6 +437,12 @@ $ xa '"abcde"::first()'
 
 $ xa '"abcde"::last()'
 # e
+
+$ xa '""::first()'
+# NULL
+
+$ xa '""::last()'
+# NULL
 ```
 
 # 文字列の置換

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -372,6 +372,58 @@ $ xa '"abcde"[1..3]'
 # bcd
 ```
 
+# 先頭・末尾の取得と除去
+
+`STRING::take(count: INT): STRING`
+
+`STRING::taker(count: INT): STRING`
+
+`STRING::drop(count: INT): STRING`
+
+`STRING::dropr(count: INT): STRING`
+
+`STRING::first(): STRING | NULL`
+
+`STRING::last(): STRING | NULL`
+
+`take` `taker` メソッドで先頭・末尾の `count` 文字を取得し、 `drop` `dropr` メソッドで先頭・末尾の `count` 文字を除去できます。
+
+`count` は数値化し、四捨五入されます。 `count` が文字列の長さを超える場合、 `take` `taker` は文字列全体を、 `drop` `dropr` は空文字列を返します。
+
+```shell
+$ xa '"abcde"::take(2)'
+# ab
+
+$ xa '"abcde"::taker(2)'
+# de
+
+$ xa '"abcde"::drop(2)'
+# cde
+
+$ xa '"abcde"::dropr(2)'
+# abc
+```
+
+`takeFirst` は `take` の、 `takeLast` は `taker` の、 `dropFirst` は `drop` の、 `dropLast` は `dropr` の別名であり、それぞれ同一の動作を持ちます。
+
+```shell
+$ xa '"abcde"::takeLast(2)'
+# de
+
+$ xa '"abcde"::dropLast(2)'
+# abc
+```
+
+`first` `last` メソッドで先頭・末尾の 1 文字を取得します。文字列が空の場合は `NULL` を返します。
+
+```shell
+$ xa '"abcde"::first()'
+# a
+
+$ xa '"abcde"::last()'
+# e
+```
+
 # 文字列の置換
 
 `STRING::replace(old: STRING | REGEX; new: STRING | (match: VALUE) -> STRING): STRING`

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
@@ -181,7 +181,7 @@ data class FluoriteString(val value: String) : FluoriteValue {
                                 if (arguments.size != 2) throw IllegalArgumentException("STRING::$name(count: INT): STRING")
                                 val string = arguments[0] as FluoriteString
                                 val count = arguments[1].toFluoriteNumber(null).roundToInt()
-                                require(count >= 0)
+                                require(count >= 0) { "STRING::$name(count: INT): STRING <- count must be non-negative, got $count" }
                                 transform(string.value, count).toFluoriteString()
                             }
                         }
@@ -197,10 +197,12 @@ data class FluoriteString(val value: String) : FluoriteValue {
                         )
                     },
                     "first" to FluoriteFunction.immediate { arguments ->
+                        if (arguments.size != 1) throw IllegalArgumentException("STRING::first(): STRING | NULL")
                         val string = arguments[0] as FluoriteString
                         string.value.firstOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
                     },
                     "last" to FluoriteFunction.immediate { arguments ->
+                        if (arguments.size != 1) throw IllegalArgumentException("STRING::last(): STRING | NULL")
                         val string = arguments[0] as FluoriteString
                         string.value.lastOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
                     },

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
@@ -175,6 +175,35 @@ data class FluoriteString(val value: String) : FluoriteValue {
                             "replaceFirst" to create("replaceFirst", false),
                         )
                     },
+                    *run {
+                        fun create(name: String, transform: (String, Int) -> String): FluoriteValue {
+                            return FluoriteFunction.immediate { arguments ->
+                                if (arguments.size != 2) throw IllegalArgumentException("STRING::$name(count: INT): STRING")
+                                val string = arguments[0] as FluoriteString
+                                val count = arguments[1].toFluoriteNumber(null).roundToInt()
+                                require(count >= 0)
+                                transform(string.value, count).toFluoriteString()
+                            }
+                        }
+                        arrayOf(
+                            "take" to create("take") { string, count -> string.take(count) },
+                            "takeFirst" to create("takeFirst") { string, count -> string.take(count) },
+                            "taker" to create("taker") { string, count -> string.takeLast(count) },
+                            "takeLast" to create("takeLast") { string, count -> string.takeLast(count) },
+                            "drop" to create("drop") { string, count -> string.drop(count) },
+                            "dropFirst" to create("dropFirst") { string, count -> string.drop(count) },
+                            "dropr" to create("dropr") { string, count -> string.dropLast(count) },
+                            "dropLast" to create("dropLast") { string, count -> string.dropLast(count) },
+                        )
+                    },
+                    "first" to FluoriteFunction.immediate { arguments ->
+                        val string = arguments[0] as FluoriteString
+                        string.value.firstOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
+                    },
+                    "last" to FluoriteFunction.immediate { arguments ->
+                        val string = arguments[0] as FluoriteString
+                        string.value.lastOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
+                    },
                 )
             )
         }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
@@ -109,6 +109,37 @@ data class FluoriteString(val value: String) : FluoriteValue {
                         }
                     },
                     *run {
+                        fun create(name: String, transform: (String, Int) -> String): FluoriteValue {
+                            return FluoriteFunction.immediate { arguments ->
+                                if (arguments.size != 2) throw IllegalArgumentException("STRING::$name(count: INT): STRING")
+                                val string = arguments[0] as FluoriteString
+                                val count = arguments[1].toFluoriteNumber(null).roundToInt()
+                                require(count >= 0) { "STRING::$name(count: INT): STRING <- count must be non-negative, got $count" }
+                                transform(string.value, count).toFluoriteString()
+                            }
+                        }
+                        arrayOf(
+                            "take" to create("take") { string, count -> string.take(count) },
+                            "takeFirst" to create("takeFirst") { string, count -> string.take(count) },
+                            "taker" to create("taker") { string, count -> string.takeLast(count) },
+                            "takeLast" to create("takeLast") { string, count -> string.takeLast(count) },
+                            "drop" to create("drop") { string, count -> string.drop(count) },
+                            "dropFirst" to create("dropFirst") { string, count -> string.drop(count) },
+                            "dropr" to create("dropr") { string, count -> string.dropLast(count) },
+                            "dropLast" to create("dropLast") { string, count -> string.dropLast(count) },
+                        )
+                    },
+                    "first" to FluoriteFunction.immediate { arguments ->
+                        if (arguments.size != 1) throw IllegalArgumentException("STRING::first(): STRING | NULL")
+                        val string = arguments[0] as FluoriteString
+                        string.value.firstOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
+                    },
+                    "last" to FluoriteFunction.immediate { arguments ->
+                        if (arguments.size != 1) throw IllegalArgumentException("STRING::last(): STRING | NULL")
+                        val string = arguments[0] as FluoriteString
+                        string.value.lastOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
+                    },
+                    *run {
                         fun create(name: String, forceAllOrFirst: Boolean?): FluoriteValue {
                             return FluoriteFunction.immediate { arguments ->
 
@@ -174,37 +205,6 @@ data class FluoriteString(val value: String) : FluoriteValue {
                             "replaceAll" to create("replaceAll", true),
                             "replaceFirst" to create("replaceFirst", false),
                         )
-                    },
-                    *run {
-                        fun create(name: String, transform: (String, Int) -> String): FluoriteValue {
-                            return FluoriteFunction.immediate { arguments ->
-                                if (arguments.size != 2) throw IllegalArgumentException("STRING::$name(count: INT): STRING")
-                                val string = arguments[0] as FluoriteString
-                                val count = arguments[1].toFluoriteNumber(null).roundToInt()
-                                require(count >= 0) { "STRING::$name(count: INT): STRING <- count must be non-negative, got $count" }
-                                transform(string.value, count).toFluoriteString()
-                            }
-                        }
-                        arrayOf(
-                            "take" to create("take") { string, count -> string.take(count) },
-                            "takeFirst" to create("takeFirst") { string, count -> string.take(count) },
-                            "taker" to create("taker") { string, count -> string.takeLast(count) },
-                            "takeLast" to create("takeLast") { string, count -> string.takeLast(count) },
-                            "drop" to create("drop") { string, count -> string.drop(count) },
-                            "dropFirst" to create("dropFirst") { string, count -> string.drop(count) },
-                            "dropr" to create("dropr") { string, count -> string.dropLast(count) },
-                            "dropLast" to create("dropLast") { string, count -> string.dropLast(count) },
-                        )
-                    },
-                    "first" to FluoriteFunction.immediate { arguments ->
-                        if (arguments.size != 1) throw IllegalArgumentException("STRING::first(): STRING | NULL")
-                        val string = arguments[0] as FluoriteString
-                        string.value.firstOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
-                    },
-                    "last" to FluoriteFunction.immediate { arguments ->
-                        if (arguments.size != 1) throw IllegalArgumentException("STRING::last(): STRING | NULL")
-                        val string = arguments[0] as FluoriteString
-                        string.value.lastOrNull()?.toString()?.toFluoriteString() ?: FluoriteNull
                     },
                 )
             )

--- a/src/commonTest/kotlin/StringTest.kt
+++ b/src/commonTest/kotlin/StringTest.kt
@@ -37,6 +37,8 @@ class StringTest {
         assertEquals("", eval("''::take(2)").string) // 空文字列からの取得
         assertEquals("ab", eval("'abcde'::take('1.5')").string) // 文字数は数値化し、四捨五入される
         assertEquals("あい", eval("'あいう'::take(2)").string) // マルチバイト文字の取得
+        assertEquals("😀", eval("'😀x'::take(2)").string) // サロゲートペアは UTF-16 コードユニット 2 つ分として扱われる
+        assertEquals(1, eval("'😀x'::take(1)").string.length) // サロゲートペアの途中（Char 単位）で分割される（既存の添字演算子と同じ挙動）
         assertFails { eval("'abcde'::take(-1)") } // 負の count はエラーになる
     }
 
@@ -79,6 +81,7 @@ class StringTest {
         assertEquals(FluoriteNull, eval("''::last()")) // 空文字列の末尾は NULL が返る
         assertEquals("あ", eval("'あいう'::first()").string) // マルチバイト文字の先頭
         assertEquals("う", eval("'あいう'::last()").string) // マルチバイト文字の末尾
+        assertEquals(1, eval("'😀x'::first()").string.length) // first はコードユニット単位なのでサロゲートペアの片方を返す（既存の添字演算子と同じ挙動）
         assertFails { eval("'abc'::first(123)") } // 余分な引数はエラーになる
         assertFails { eval("'abc'::last(123)") } // 余分な引数はエラーになる
     }

--- a/src/commonTest/kotlin/StringTest.kt
+++ b/src/commonTest/kotlin/StringTest.kt
@@ -5,6 +5,7 @@ import mirrg.xarpite.test.eval
 import mirrg.xarpite.test.string
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StringTest {
@@ -36,6 +37,7 @@ class StringTest {
         assertEquals("", eval("''::take(2)").string) // 空文字列からの取得
         assertEquals("ab", eval("'abcde'::take('1.5')").string) // 文字数は数値化し、四捨五入される
         assertEquals("あい", eval("'あいう'::take(2)").string) // マルチバイト文字の取得
+        assertFails { eval("'abcde'::take(-1)") } // 負の count はエラーになる
     }
 
     @Test
@@ -56,6 +58,7 @@ class StringTest {
         assertEquals("", eval("'abcde'::drop(10)").string) // 長さを超える場合は空文字列になる
         assertEquals("", eval("''::drop(2)").string) // 空文字列からの除去
         assertEquals("う", eval("'あいう'::drop(2)").string) // マルチバイト文字の除去
+        assertFails { eval("'abcde'::drop(-1)") } // 負の count はエラーになる
     }
 
     @Test
@@ -76,6 +79,8 @@ class StringTest {
         assertEquals(FluoriteNull, eval("''::last()")) // 空文字列の末尾は NULL が返る
         assertEquals("あ", eval("'あいう'::first()").string) // マルチバイト文字の先頭
         assertEquals("う", eval("'あいう'::last()").string) // マルチバイト文字の末尾
+        assertFails { eval("'abc'::first(123)") } // 余分な引数はエラーになる
+        assertFails { eval("'abc'::last(123)") } // 余分な引数はエラーになる
     }
 
     @Test

--- a/src/commonTest/kotlin/StringTest.kt
+++ b/src/commonTest/kotlin/StringTest.kt
@@ -1,5 +1,6 @@
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import mirrg.xarpite.compilers.objects.FluoriteNull
 import mirrg.xarpite.test.eval
 import mirrg.xarpite.test.string
 import kotlin.test.Test
@@ -24,6 +25,57 @@ class StringTest {
     fun concatenate() = runTest {
         assertEquals("ab", eval(" 'a' & 'b' ").string) // & で文字列の連結ができる
         assertEquals("12", eval(" 1 & 2 ").string) // 文字列に変換する
+    }
+
+    @Test
+    fun take() = runTest {
+        assertEquals("ab", eval("'abcde'::take(2)").string) // 先頭の n 文字を取得する
+        assertEquals("ab", eval("'abcde'::takeFirst(2)").string) // takeFirst は take のシノニム
+        assertEquals("", eval("'abcde'::take(0)").string) // 0 文字は空文字列になる
+        assertEquals("abcde", eval("'abcde'::take(10)").string) // 長さを超える場合は文字列全体になる
+        assertEquals("", eval("''::take(2)").string) // 空文字列からの取得
+        assertEquals("ab", eval("'abcde'::take('1.5')").string) // 文字数は数値化し、四捨五入される
+        assertEquals("あい", eval("'あいう'::take(2)").string) // マルチバイト文字の取得
+    }
+
+    @Test
+    fun taker() = runTest {
+        assertEquals("de", eval("'abcde'::taker(2)").string) // 末尾の n 文字を取得する
+        assertEquals("de", eval("'abcde'::takeLast(2)").string) // takeLast は taker のシノニム
+        assertEquals("", eval("'abcde'::taker(0)").string) // 0 文字は空文字列になる
+        assertEquals("abcde", eval("'abcde'::taker(10)").string) // 長さを超える場合は文字列全体になる
+        assertEquals("", eval("''::taker(2)").string) // 空文字列からの取得
+        assertEquals("いう", eval("'あいう'::taker(2)").string) // マルチバイト文字の取得
+    }
+
+    @Test
+    fun drop() = runTest {
+        assertEquals("cde", eval("'abcde'::drop(2)").string) // 先頭の n 文字を除く
+        assertEquals("cde", eval("'abcde'::dropFirst(2)").string) // dropFirst は drop のシノニム
+        assertEquals("abcde", eval("'abcde'::drop(0)").string) // 0 文字は文字列全体になる
+        assertEquals("", eval("'abcde'::drop(10)").string) // 長さを超える場合は空文字列になる
+        assertEquals("", eval("''::drop(2)").string) // 空文字列からの除去
+        assertEquals("う", eval("'あいう'::drop(2)").string) // マルチバイト文字の除去
+    }
+
+    @Test
+    fun dropr() = runTest {
+        assertEquals("abc", eval("'abcde'::dropr(2)").string) // 末尾の n 文字を除く
+        assertEquals("abc", eval("'abcde'::dropLast(2)").string) // dropLast は dropr のシノニム
+        assertEquals("abcde", eval("'abcde'::dropr(0)").string) // 0 文字は文字列全体になる
+        assertEquals("", eval("'abcde'::dropr(10)").string) // 長さを超える場合は空文字列になる
+        assertEquals("", eval("''::dropr(2)").string) // 空文字列からの除去
+        assertEquals("あ", eval("'あいう'::dropr(2)").string) // マルチバイト文字の除去
+    }
+
+    @Test
+    fun firstAndLast() = runTest {
+        assertEquals("a", eval("'abc'::first()").string) // 先頭の 1 文字を取得する
+        assertEquals("c", eval("'abc'::last()").string) // 末尾の 1 文字を取得する
+        assertEquals(FluoriteNull, eval("''::first()")) // 空文字列の先頭は NULL が返る
+        assertEquals(FluoriteNull, eval("''::last()")) // 空文字列の末尾は NULL が返る
+        assertEquals("あ", eval("'あいう'::first()").string) // マルチバイト文字の先頭
+        assertEquals("う", eval("'あいう'::last()").string) // マルチバイト文字の末尾
     }
 
     @Test


### PR DESCRIPTION
STREAM の先頭/末尾ファミリー（`TAKE`/`TAKER`/`DROP`/`DROPR`/`FIRST`/`LAST`）を、STRING の小文字メソッドとして文字単位で写すのだ〜🌱 元ネタは [Issue #551](https://github.com/MirrgieRiana/xarpite/issues/551) なのだ。

## 追加するメソッドなのだ

| メソッド | シノニム | はたらき | 対応 STREAM |
|---|---|---|---|
| `take(n)` | `takeFirst(n)` | 先頭 **n文字** | `TAKE` |
| `taker(n)` | `takeLast(n)` | 末尾 **n文字** | `TAKER` |
| `drop(n)` | `dropFirst(n)` | 先頭 **n文字** を除く | `DROP` |
| `dropr(n)` | `dropLast(n)` | 末尾 **n文字** を除く | `DROPR` |
| `first` | — | 先頭 **1文字** | `FIRST` |
| `last` | — | 末尾 **1文字** | `LAST` |

`taker`/`dropr` は `TAKER`/`DROPR` との綴りの一貫性側、`takeLast`/`dropLast` などは可読性側のシノニムで、`FILTER`/`GREP` のように文脈で意味論的に選べる住み分けなのだ。

## 変更点なのだ

- **`FluoriteString.kt`**: 上記メソッド群を実装するのだ。
- **`StringTest.kt`**: 境界（空文字列・`n=0`・長さ超過・シノニムの一致）も含めてテストするのだ。
- **`pages/docs/ja/string.md`, `pages/docs/en/string.md`**: 「部分文字列の取得」のおとなりに追記するのだ。
- **`changelog.d/`**: チェンジログのかけらを追加するのだ。

---

このPRの文脈や経緯は [Issue #551](https://github.com/MirrgieRiana/xarpite/issues/551) のやりとりを参照してほしいのだ。
