### PR TITLE
DOUBLEのroundToIntはNaNでエラーを出すべきなのだ。

### DIFF
--- a/changelog.d/round-to-int-nan-error.md
+++ b/changelog.d/round-to-int-nan-error.md
@@ -1,0 +1,1 @@
+?Fixed an index, count, or similar value of `NaN` being silently treated as `0` instead of raising an error.

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
@@ -2,6 +2,7 @@ package mirrg.xarpite.compilers.objects
 
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import mirrg.xarpite.OperatorMethod
+import mirrg.xarpite.operations.FluoriteException
 import mirrg.xarpite.toFluoriteIntAsCompared
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -114,7 +115,10 @@ data class FluoriteDouble(val value: Double) : FluoriteNumber {
     override fun toInt() = value.toBigDecimal().intValue(true)
     override fun toDouble() = value
     override fun negate() = FluoriteDouble(-value)
-    override fun roundToInt() = value.roundToInt()
+    override fun roundToInt(): Int {
+        if (value.isNaN()) throw FluoriteException("Cannot round NaN to an integer".toFluoriteString())
+        return value.roundToInt()
+    }
 }
 
 fun String.toFluoriteNumber(): FluoriteNumber {

--- a/src/commonTest/kotlin/MathTest.kt
+++ b/src/commonTest/kotlin/MathTest.kt
@@ -2,11 +2,13 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mirrg.xarpite.compilers.objects.FluoriteInt
 import mirrg.xarpite.compilers.objects.invokeImmediate
+import mirrg.xarpite.operations.FluoriteException
 import mirrg.xarpite.test.double
 import mirrg.xarpite.test.eval
 import mirrg.xarpite.test.int
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -17,6 +19,14 @@ class MathTest {
         assertEquals(10, eval("FLOOR(10.1)").int) // FLOOR関数は小数点以下を切り捨てて内部的な型をINTにする
         assertEquals(10, eval("FLOOR(10)").int) // 整数はそのまま
         assertEquals(-11, eval("FLOOR(-10.1)").int) // 負の数も値が小さくなるように切り捨てる
+    }
+
+    @Test
+    fun roundToIntRejectsNaN() = runTest {
+        // 数値をINTに丸める箇所では、NaNを0として扱わずにエラーにする
+        assertFailsWith<FluoriteException> { eval("[10;20;30](+'NaN')") } // 配列のインデックス
+        assertFailsWith<FluoriteException> { eval("'abc'(+'NaN')") } // 文字列のインデックス
+        assertFailsWith<FluoriteException> { eval("BASE(10; +'NaN')") } // BASE関数の数値引数
     }
 
     @Test


### PR DESCRIPTION
Claude Fairyは https://github.com/MirrgieRiana/private/issues/16 に記載の Protocol 103F 必読なのだ

<!-- このPRを処理するには original issue に記載の protocol 103f および[プロトコル102](/.github/protocol-102.md)の必読が必須です。 -->

## 概要なのだ

`FluoriteDouble.roundToInt()` はKotlin標準の `Double.roundToInt()` に委譲しているため、`NaN` を渡すと暗黙に `0` を返していたのだ。

この丸め処理は、配列・文字列のインデックスアクセス、`BASE`/`BASED` の数値、`TAKE`/`DROP` 系の個数、`STORE` の上限など、数値をINTに丸めるあらゆる箇所で使われているのだ。
そのため `NaN` が紛れ込むと、本来エラーであるべき場面で静かに `0` 番目の要素や `0` 個として扱われてしまっていたのだ。

本来想定していなかったこの挙動を修正し、`NaN` の丸め時に明示的にエラーを投げるようにしたのだ。これはFix扱いなのだ。

## 変更内容なのだ

- `FluoriteDouble.roundToInt()` で `NaN` を受け取った場合に `FluoriteException` を投げるよう修正したのだ
- `MathTest` に、インデックス・`BASE` 引数での `NaN` がエラーになることを確認するテストを追加したのだ
- `changelog.d/round-to-int-nan-error.md` を追加したのだ（`?Fixed`）

## 補足なのだ

- `Infinity` は `roundToInt()` で `Int.MAX_VALUE` / `Int.MIN_VALUE` になるのだけど、本PRのスコープ（`NaN`）からは外れるため挙動は変更していないのだ。必要であれば別途ご相談なのだ。
- このPRは PR MirrgieRiana/xarpite#540 のレビューで見つかった、文字コード変換関数の `isFinite` 判定に関する議論が発端なのだ。当該判定は MirrgieRiana/xarpite#540 側から削除し、根本原因であるこちらで対応しているのだ。
