### PR TITLE
.gitignore から不要になった `/CLAUDE.md` エントリを削除するのだ。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ build/
 *.tmp
 .xarpite/
 /.codex
-/CLAUDE.md


### PR DESCRIPTION
Claude Fairyは https://github.com/MirrgieRiana/private/issues/16 に記載の Protocol 103F 必読なのだ

<!-- このPRを処理するには original issue に記載の protocol 103f の必読が必須です。 -->

## 概要なのだ

当初この PR は、リポジトリ直下に案内文を持つ `CLAUDE.md` を新規追加して、`.github/copilot-instructions.md` の読み方を案内する方針だったのだ。

その後 main 側で指示文まわりが刷新され、`CLAUDE.md`（Claude 向けの入口）・`AGENTS.md`（全 AI 共通のリポジトリ固有指示）・`copilot-instructions.md`（Copilot 固有指示）の三層に整理されたのだ。これにより当初の案内文は別解で達成済みとなり、この PR の前提が変わったのだ。

そこで本 PR は、[こちらの考察コメント](https://github.com/MirrgieRiana/xarpite/pull/557#issuecomment-4641210700)の選択肢 (B) に沿って、唯一生き残った論点だけを残す最小 PR に作り替えたのだ。すなわち、main 側で `CLAUDE.md` が追跡対象になっているにもかかわらず `.gitignore` に残り続けている `/CLAUDE.md` エントリ（追跡済みファイルに対しては効果が無く、矛盾した状態）を削除するのだ。

## 変更点なのだ

- **`.gitignore`**: 不要になった `/CLAUDE.md` エントリを削除するのだ。`CLAUDE.md` は既に追跡されているため、このエントリは効果が無く矛盾した状態だったのだ。
- **`changelog.d/remove-claude-md-gitignore-entry.md`**: チェンジログのかけらを追加するのだ。ユーザーから見える言語機能の変更ではないため、中身は空にしてあるのだ。

## 補足なのだ

- 当初追加予定だった案内文 `CLAUDE.md` は、main 側の三層整理で役目を終えたため、本 PR では追加しないのだ。
- 経緯の詳細は[この考察コメント](https://github.com/MirrgieRiana/xarpite/pull/557#issuecomment-4641210700)を参照なのだ。元ネタは [Issue MirrgieRiana/xarpite#550](https://github.com/MirrgieRiana/xarpite/issues/550) なのだ〜🌱
