### PR TITLE
JSON 系関数の `indent` に `NULL` を指定できるようにするのだ。

### DIFF
--- a/changelog.d/add-json-indent-null.md
+++ b/changelog.d/add-json-indent-null.md
@@ -1,0 +1,1 @@
+Added support for passing `NULL` as the `indent` argument of the `JSON`, `JSONS`, and `JSONL` functions to produce compact output without indentation.

--- a/pages/docs/en/data-conversion.md
+++ b/pages/docs/en/data-conversion.md
@@ -282,7 +282,7 @@ $ xa "SHELL_ESCAPE(%>Don't ask<%)"
 
 ## `JSON` Convert Value to JSON String
 
-`JSON([indent: [indent: ]STRING | NUMBER; ]value: VALUE): STRING`
+`JSON([indent: [indent: ]STRING | NUMBER | NULL; ]value: VALUE): STRING`
 
 Converts `value` to a JSON-formatted string.
 
@@ -315,6 +315,15 @@ $ xa '{a: 1; b: 2} >> JSON[indent: 2]'
 # }
 ```
 
+---
+
+If you pass `NULL` to `indent`, no indentation is used and the output is compact.
+
+```shell
+$ xa '{a: 1; b: 2} >> JSON[indent: NULL]'
+# {"a":1,"b":2}
+```
+
 ## `JSOND` Convert JSON String to Value
 
 `JSOND(json: STRING): VALUE`
@@ -328,7 +337,7 @@ $ xa ' "{\"a\": 1, \"b\": 2}" >> JSOND '
 
 ## `JSONS` / `JSONL` Convert Stream of Values to Stream of JSON Strings
 
-`JSONS([indent: [indent: ]STRING | NUMBER; ]values: STREAM<VALUE>): STREAM<STRING>`
+`JSONS([indent: [indent: ]STRING | NUMBER | NULL; ]values: STREAM<VALUE>): STREAM<STRING>`
 
 Returns a stream that converts each element of `values` to a JSON-formatted string.
 

--- a/pages/docs/ja/data-conversion.md
+++ b/pages/docs/ja/data-conversion.md
@@ -282,7 +282,7 @@ $ xa "SHELL_ESCAPE(%>Don't ask<%)"
 
 ## `JSON` 値をJSON文字列に変換
 
-`JSON([indent: [indent: ]STRING | NUMBER; ]value: VALUE): STRING`
+`JSON([indent: [indent: ]STRING | NUMBER | NULL; ]value: VALUE): STRING`
 
 `value` をJSON形式の文字列に変換します。
 
@@ -315,6 +315,15 @@ $ xa '{a: 1; b: 2} >> JSON[indent: 2]'
 # }
 ```
 
+---
+
+`indent` に `NULL` を指定した場合、インデントは使用されず、コンパクトな出力になります。
+
+```shell
+$ xa '{a: 1; b: 2} >> JSON[indent: NULL]'
+# {"a":1,"b":2}
+```
+
 ## `JSOND` JSON文字列を値に変換
 
 `JSOND(json: STRING): VALUE`
@@ -328,7 +337,7 @@ $ xa ' "{\"a\": 1, \"b\": 2}" >> JSOND '
 
 ## `JSONS` / `JSONL` 値のストリームをJSON文字列のストリームに変換
 
-`JSONS([indent: [indent: ]STRING | NUMBER; ]values: STREAM<VALUE>): STREAM<STRING>`
+`JSONS([indent: [indent: ]STRING | NUMBER | NULL; ]values: STREAM<VALUE>): STREAM<STRING>`
 
 `values` の各要素をJSON形式の文字列に変換するストリームを返します。
 

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
@@ -5,6 +5,7 @@ import mirrg.xarpite.RuntimeContext
 import mirrg.xarpite.compilers.objects.FluoriteArray
 import mirrg.xarpite.compilers.objects.FluoriteFunction
 import mirrg.xarpite.compilers.objects.FluoriteInt
+import mirrg.xarpite.compilers.objects.FluoriteNull
 import mirrg.xarpite.compilers.objects.FluoriteNumber
 import mirrg.xarpite.compilers.objects.FluoriteStream
 import mirrg.xarpite.compilers.objects.FluoriteString
@@ -170,8 +171,10 @@ fun createDataConversionMounts(): List<Map<String, Mount>> {
             )
         },
         *run {
-            suspend fun parseIndent(indent: FluoriteValue): String {
-                return if (indent is FluoriteNumber) {
+            suspend fun parseIndent(indent: FluoriteValue): String? {
+                return if (indent is FluoriteNull) {
+                    null
+                } else if (indent is FluoriteNumber) {
                     val number = indent.roundToInt()
                     if (number <= 0) throw FluoriteException("Indent must be positive".toFluoriteString())
                     " ".repeat(number)

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
@@ -184,7 +184,7 @@ fun createDataConversionMounts(): List<Map<String, Mount>> {
             }
             arrayOf(
                 "JSON" define FluoriteFunction.immediate { arguments ->
-                    fun usage(): Nothing = usage("JSON([indent: [indent: ]STRING | NUMBER; ]value: VALUE): STRING")
+                    fun usage(): Nothing = usage("JSON([indent: [indent: ]STRING | NUMBER | NULL; ]value: VALUE): STRING")
                     val arguments2 = arguments.toMutableList()
 
                     if (arguments2.isEmpty()) usage()
@@ -208,7 +208,7 @@ fun createDataConversionMounts(): List<Map<String, Mount>> {
                 *run {
                     fun create(name: String): FluoriteFunction {
                         return FluoriteFunction.immediate { arguments ->
-                            fun usage(): Nothing = usage("$name([indent: [indent: ]STRING | NUMBER; ]values: STREAM<VALUE>): STREAM<STRING>")
+                            fun usage(): Nothing = usage("$name([indent: [indent: ]STRING | NUMBER | NULL; ]values: STREAM<VALUE>): STREAM<STRING>")
                             val arguments2 = arguments.toMutableList()
 
                             if (arguments2.isEmpty()) usage()

--- a/src/commonTest/kotlin/DataConversionTest.kt
+++ b/src/commonTest/kotlin/DataConversionTest.kt
@@ -41,6 +41,10 @@ class DataConversionTest {
             eval(""" {a: 1}, {b: 2} >> JSONS[indent: 2] """).stream(),
             eval(""" {a: 1}, {b: 2} >> JSONS["  "] """).stream()
         ) // JSONS でindentは位置引数でも指定できる
+        assertEquals(
+            eval(""" {a: 1}, {b: 2} >> JSONS """).stream(),
+            eval(""" {a: 1}, {b: 2} >> JSONS[indent: NULL] """).stream()
+        ) // JSONS でindentにNULLを指定するとインデント無しになる
 
         // JSOND
         assertEquals("""{a:[1;2.5;3;TRUE;FALSE;NULL]}""", eval(""" '{"a":[1,2.5,"3",true,false,null]}' >> JSOND """).obj) // JSOND でJson文字列を値に変換する
@@ -54,6 +58,10 @@ class DataConversionTest {
         // JSONL (synonym for JSONS)
         assertEquals("[1],[2],[3]", eval("[1], [2], [3] >> JSONL").stream()) // JSONLはJSONSのシノニムとして動作する
         assertEquals("[\n  1\n],[\n  2\n],[\n  3\n]", eval(""" [1], [2], [3] >> JSONL[indent: "  "] """).stream()) // indentオプションも使用できる
+        assertEquals(
+            eval(""" [1], [2], [3] >> JSONL """).stream(),
+            eval(""" [1], [2], [3] >> JSONL[indent: NULL] """).stream()
+        ) // JSONL でもindentにNULLを指定するとインデント無しになる
 
         // JSONLD (synonym for JSONSD)
         assertEquals("[1],[2],[3]", eval(""" "[1]", "[2]", "[3]" >> JSONLD """).stream()) // JSONLDはJSONSDのシノニムとして動作する

--- a/src/commonTest/kotlin/DataConversionTest.kt
+++ b/src/commonTest/kotlin/DataConversionTest.kt
@@ -30,6 +30,10 @@ class DataConversionTest {
             eval(""" {a: 1} >> JSON[indent: "  "] """).string,
             eval(""" {a: 1} >> JSON[indent: 2] """).string
         ) // indentは数値でも指定でき、その数だけ空白が使用される
+        assertEquals(
+            eval(""" {a: 1} >> JSON """).string,
+            eval(""" {a: 1} >> JSON[indent: NULL] """).string
+        ) // indentにNULLを指定するとインデント無しになる
 
         // JSONS
         assertEquals("[\n 1\n],[\n 2\n]", eval(""" [1], [2] >> JSONS[indent: 1] """).stream()) // JSONS でindentを指定できる


### PR DESCRIPTION
## 概要

`JSON` / `JSONS` / `JSONL` 関数の `indent` 引数に `NULL` を指定できるようにし、インデント無しのコンパクト出力を得られるようにするのだ。

現状の `JSON[indent: NULL]` は、`NULL` が文字列 `NULL` としてインデントに使われようとして失敗し、xarpite に捕捉されない生の Java 例外が漏れてしまうのだ。`indent: NULL` を「インデント指定なし」として扱えるようにするのが、このPRの趣旨なのだ。

Claude Fairyは https://github.com/MirrgieRiana/private/issues/16 に記載の Protocol 103F 必読なのだ

## 背景

このPRは Issue MirrgieRiana/xarpite#549 の議論から派生したものなのだ。`JSON[indent: NULL]` の現状の挙動の調査結果など、詳しい経緯はそちらを参照なのだ〜。

Closes MirrgieRiana/xarpite#549
