### PR TITLE
TO_ARRAY・TO_OBJECT の usage メッセージの関数名を修正するのだ。

### DIFF
--- a/changelog.d/convert-usage-function-names.md
+++ b/changelog.d/convert-usage-function-names.md
@@ -1,0 +1,1 @@
+?Fixed the usage messages of `TO_ARRAY` and `TO_OBJECT` showing the wrong function name.

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/ConvertMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/ConvertMounts.kt
@@ -46,14 +46,14 @@ fun createConvertMounts(): List<Map<String, Mount>> {
                 }
                 list.asFluoriteArray()
             } else {
-                usage("ARRAY(stream: STREAM<VALUE>): ARRAY<VALUE>")
+                usage("TO_ARRAY(stream: STREAM<VALUE>): ARRAY<VALUE>")
             }
         },
         "TO_OBJECT" define FluoriteFunction.immediate { arguments ->
             if (arguments.size == 1) {
                 FluoriteObject.fromStream(arguments[0])
             } else {
-                usage("OBJECT(stream: STREAM<ARRAY<STRING; VALUE>>): OBJECT")
+                usage("TO_OBJECT(stream: STREAM<ARRAY<STRING; VALUE>>): OBJECT")
             }
         },
     ).let { listOf(it) }

--- a/src/commonTest/kotlin/ArrayTest.kt
+++ b/src/commonTest/kotlin/ArrayTest.kt
@@ -1,6 +1,7 @@
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mirrg.xarpite.compilers.objects.FluoriteNull
+import mirrg.xarpite.operations.FluoriteException
 import mirrg.xarpite.test.array
 import mirrg.xarpite.test.eval
 import mirrg.xarpite.test.int
@@ -8,6 +9,8 @@ import mirrg.xarpite.test.parse
 import mirrg.xarpite.test.stream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ArrayTest {
@@ -32,6 +35,12 @@ class ArrayTest {
         assertEquals("[1;2;3]", eval("(1, 2, 3).[]").array()) // .[] 配列化演算子
         assertEquals("[10;20;30]", eval("(1 .. 3 | _ * 10).[]").array()) // .[] 配列化演算子とパイプの組み合わせ
         assertEquals("[100]", eval("100.[]").array()) // ストリームでなくてもよい
+    }
+
+    @Test
+    fun toArrayUsage() = runTest {
+        val exception = assertFailsWith<FluoriteException> { eval("TO_ARRAY(1; 2)") } // 引数の数が不正だと usage メッセージを出す
+        assertTrue(exception.message!!.contains("TO_ARRAY")) // usage メッセージの関数名が TO_ARRAY になっている
     }
 
     @Test

--- a/src/commonTest/kotlin/ObjectTest.kt
+++ b/src/commonTest/kotlin/ObjectTest.kt
@@ -1,5 +1,6 @@
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import mirrg.xarpite.operations.FluoriteException
 import mirrg.xarpite.test.boolean
 import mirrg.xarpite.test.eval
 import mirrg.xarpite.test.int
@@ -7,6 +8,7 @@ import mirrg.xarpite.test.obj
 import mirrg.xarpite.test.stream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -95,6 +97,12 @@ class ObjectTest {
         assertEquals("{a:1;b:2}", eval("((a: 1), (b: 2)).{}").obj) // .{} オブジェクト化演算子
         assertEquals("{az:10;bz:20;cz:30}", eval("({a: 1; b: 2; c: 3}() | (_.0 & \"z\": _.1 * 10)).{}").obj) // .{} オブジェクト化演算子とパイプの組み合わせ
         assertEquals("{a:100}", eval("(a: 100).{}").obj) // ストリームでなくてもよい
+    }
+
+    @Test
+    fun toObjectUsage() = runTest {
+        val exception = assertFailsWith<FluoriteException> { eval("TO_OBJECT(1; 2)") } // 引数の数が不正だと usage メッセージを出す
+        assertTrue(exception.message!!.contains("TO_OBJECT")) // usage メッセージの関数名が TO_OBJECT になっている
     }
 
 


### PR DESCRIPTION
Claude Fairyは https://github.com/MirrgieRiana/private/issues/16 に記載の Protocol 103F 必読なのだ

<!-- このPRを処理するには original issue に記載の protocol 103f および[プロトコル102](/.github/protocol-102.md)の必読が必須です。 -->

Closes MirrgieRiana/xarpite#496

このPRは、Issue MirrgieRiana/xarpite#496 のコメント https://github.com/MirrgieRiana/xarpite/issues/496#issuecomment-4642085672 を発端に作成したのだ。

## 概要なのだ

`TO_ARRAY` / `TO_OBJECT` 関数に誤った数の引数を渡したときに表示される usage メッセージで、先頭の関数名が `ARRAY(...)` / `OBJECT(...)` と、実際の関数名を取りこぼしていたのだ。

兄弟関数の `TO_STRING` / `TO_NUMBER` / `TO_BOOLEAN` をはじめ、リポジトリ全体では usage メッセージの先頭を実際の関数名と一致させる慣例なのに、この2か所だけが不一致だったのだ。これを実際の関数名 `TO_ARRAY` / `TO_OBJECT` に揃えるのだ。これはFix扱いなのだ。

## 変更内容なのだ

- `ConvertMounts.kt` の `TO_ARRAY` / `TO_OBJECT` の usage メッセージの先頭関数名を修正したのだ（引数・戻り値の記述は元のまま維持なのだ）
- `ArrayTest` / `ObjectTest` に、usage メッセージへ正しい関数名が含まれることを確認する回帰テストを追加したのだ
- `changelog.d/` に断片を追加したのだ（`?Fixed`）