### PR TITLE
ネイティブエラーを送出する `ERROR.throwNativeError` 関数を追加するのだ。

### DIFF
--- a/changelog.d/add-error-throw-native-error-function.md
+++ b/changelog.d/add-error-throw-native-error-function.md
@@ -1,0 +1,1 @@
+Added `ERROR.throwNativeError` function that throws a native error with the given message.

--- a/pages/docs/en/jump.md
+++ b/pages/docs/en/jump.md
@@ -453,3 +453,12 @@ You can determine whether a value is a native error with `value ?= ERROR`.
 The `message` property retrieves the message of the native error.
 
 It becomes `NULL` if there is no message.
+
+## `throwNativeError`: Throwing a Native Error
+
+`ERROR.throwNativeError` throws a native error with the given message.
+
+```shell
+$ xa 'ERROR.throwNativeError("Something went wrong") !? ( e => e.message )'
+# Something went wrong
+```

--- a/pages/docs/en/jump.md
+++ b/pages/docs/en/jump.md
@@ -456,7 +456,9 @@ It becomes `NULL` if there is no message.
 
 ## `throwNativeError`: Throwing a Native Error
 
-`ERROR.throwNativeError` throws a native error with the given message.
+`ERROR.throwNativeError(message: STRING): NOTHING`
+
+Throws a native error with the given message.
 
 ```shell
 $ xa 'ERROR.throwNativeError("Something went wrong") !? ( e => e.message )'

--- a/pages/docs/ja/jump.md
+++ b/pages/docs/ja/jump.md
@@ -453,3 +453,12 @@ $ xa '
 `message` プロパティにより、ネイティブエラーのメッセージを取得できます。
 
 メッセージが存在しない場合は `NULL` になります。
+
+## `throwNativeError`: ネイティブエラーの送出
+
+`ERROR.throwNativeError` により、指定したメッセージを持つネイティブエラーを送出できます。
+
+```shell
+$ xa 'ERROR.throwNativeError("Something went wrong") !? ( e => e.message )'
+# Something went wrong
+```

--- a/pages/docs/ja/jump.md
+++ b/pages/docs/ja/jump.md
@@ -456,6 +456,8 @@ $ xa '
 
 ## `throwNativeError`: ネイティブエラーのスロー
 
+`ERROR.throwNativeError(message: STRING): NOTHING`
+
 指定したメッセージを持つネイティブエラーをスローします。
 
 ```shell

--- a/pages/docs/ja/jump.md
+++ b/pages/docs/ja/jump.md
@@ -454,9 +454,9 @@ $ xa '
 
 メッセージが存在しない場合は `NULL` になります。
 
-## `throwNativeError`: ネイティブエラーの送出
+## `throwNativeError`: ネイティブエラーのスロー
 
-`ERROR.throwNativeError` により、指定したメッセージを持つネイティブエラーを送出できます。
+指定したメッセージを持つネイティブエラーをスローします。
 
 ```shell
 $ xa 'ERROR.throwNativeError("Something went wrong") !? ( e => e.message )'

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
@@ -1,6 +1,7 @@
 package mirrg.xarpite.compilers.objects
 
 import mirrg.xarpite.OperatorMethod
+import mirrg.xarpite.mounts.usage
 import mirrg.xarpite.operations.FluoriteException
 
 class FluoriteError(val throwable: Throwable) : FluoriteValue {
@@ -8,6 +9,11 @@ class FluoriteError(val throwable: Throwable) : FluoriteValue {
         val fluoriteClass by lazy {
             FluoriteObject(
                 FluoriteValue.fluoriteClass, mutableMapOf(
+                    "throwNativeError" to FluoriteFunction.immediate { arguments ->
+                        if (arguments.size != 1) usage("ERROR.throwNativeError(message: STRING): NOTHING")
+                        val message = arguments[0].toFluoriteString(null).value
+                        throw RuntimeException(message)
+                    },
                     OperatorMethod.PROPERTY.methodName to FluoriteFunction.immediate { arguments ->
                         val error = arguments[0] as FluoriteError
                         val key = arguments[1].toFluoriteString(null).value

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
@@ -9,11 +9,6 @@ class FluoriteError(val throwable: Throwable) : FluoriteValue {
         val fluoriteClass by lazy {
             FluoriteObject(
                 FluoriteValue.fluoriteClass, mutableMapOf(
-                    "throwNativeError" to FluoriteFunction.immediate { arguments ->
-                        if (arguments.size != 1) usage("ERROR.throwNativeError(message: STRING): NOTHING")
-                        val message = arguments[0].toFluoriteString(null).value
-                        throw RuntimeException(message)
-                    },
                     OperatorMethod.PROPERTY.methodName to FluoriteFunction.immediate { arguments ->
                         val error = arguments[0] as FluoriteError
                         val key = arguments[1].toFluoriteString(null).value
@@ -21,6 +16,11 @@ class FluoriteError(val throwable: Throwable) : FluoriteValue {
                             "message" -> error.throwable.message?.toFluoriteString() ?: FluoriteNull
                             else -> throw FluoriteException("No such property: $key".toFluoriteString())
                         }
+                    },
+                    "throwNativeError" to FluoriteFunction.immediate { arguments ->
+                        if (arguments.size != 1) usage("ERROR.throwNativeError(message: STRING): NOTHING")
+                        val message = arguments[0].toFluoriteString(null).value
+                        throw RuntimeException(message)
                     },
                 )
             )

--- a/src/commonTest/kotlin/XarpiteTest.kt
+++ b/src/commonTest/kotlin/XarpiteTest.kt
@@ -531,6 +531,13 @@ class XarpiteTest {
     }
 
     @Test
+    fun throwNativeErrorTest() = runTest {
+        assertEquals(true, eval("ERROR.throwNativeError('boom') !? ( e => e ?= ERROR )").boolean) // throwNativeError はネイティブエラーを送出し、!? で ERROR として捕捉できる
+        assertEquals("boom", eval("ERROR.throwNativeError('boom') !? ( e => e.message )").string) // 送出したネイティブエラーは渡したメッセージを保持する
+        assertFails { eval("ERROR.throwNativeError('boom')") } // 捕捉しなければネイティブエラーがそのまま伝搬する
+    }
+
+    @Test
     fun accessTest() = runTest {
         assertEquals("b", eval(" 'abc'.1 ").string) // 文字列に数値アクセスするとそのインデックスの文字を得る
         assertEquals(FluoriteNull, eval(" 'abc'.(-1) ")) // 負のインデックスは無効


### PR DESCRIPTION
## 概要

ネイティブエラーを確実に送出する正規 API として `ERROR.throwNativeError(message: STRING): NOTHING` を追加するのだ。

`ERROR.throwNativeError("...")` は、指定したメッセージを持つネイティブエラー（ホスト言語の例外）を送出するのだ。送出されたエラーは `!?` で `ERROR` として捕捉でき、`message` プロパティで元のメッセージを取得できるのだ。

```shell
$ xa 'ERROR.throwNativeError("Something went wrong") !? ( e => e.message )'
# Something went wrong
```

## 背景

このPRは #561 の議論から派生したものなのだ。

#561 は JSON のエンコード/デコードの失敗を文字列エラーに変換するのだけど、その副作用として `JSOND('{')` がネイティブエラーを投げなくなるのだ。ところが #567 由来のテスト群が `JSOND('{')` を「ネイティブエラーを出す代表的な手段」として利用しており、この偶発的な結びつきが #561 によって表面化したのだ。

そこで、テストやドキュメントに「意図が明示された、壊れにくいネイティブエラー源」を与えるために、専用の正規 API `ERROR.throwNativeError` を新設するのだ。`PROMISE.new` / `BLOB.of` と同じく、クラスオブジェクト上の静的関数として提供するのだ。

#561 側では、このPRの先行マージを見越して、`JSOND('{')` をネイティブエラー源として使っていた箇所を `ERROR.throwNativeError(...)` に差し替えるのだ。

詳しい経緯は #561 およびそのスレッドを参照なのだ〜。