### PR TITLE
CHAR_CODES / CHAR_CODESD を追加しちゃうのだっ！

### DIFF
--- a/changelog.d/add-char-codes-functions.md
+++ b/changelog.d/add-char-codes-functions.md
@@ -1,0 +1,1 @@
+Added `CHAR_CODES` and `CHAR_CODESD` functions for converting between strings and UTF-16 code unit values.

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -553,10 +553,8 @@ Functions with the `D` suffix decode, while those without it encode.
 
 An error is raised for inputs that fall under any of the following:
 
-- `CHAR_CODED` / `CHAR_CODESD`: given a value that is not between 0 and 65535
+- `CHAR_CODED` `CHAR_CODESD`: given a value that is not between 0 and 65535
 - `CHAR_CODE`: given a string that does not consist of exactly one code unit
-
-For `CHAR_CODESD`, which takes a stream, the numeric condition is checked for each element.
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -571,13 +569,13 @@ $ xa 'CHAR_CODED(65)'
 $ xa 'CHAR_CODED(12354)'
 # あ
 
-$ xa 'JSONS(TO_ARRAY(CHAR_CODES("ABC")))'
-# [65,66,67]
+$ xa 'CHAR_CODES("ABC") >> JOIN[","]'
+# 65,66,67
 
 $ xa 'CHAR_CODESD(65, 66, 67)'
 # ABC
 
-$ xa 'CHAR_CODESD(CHAR_CODES("Hello"))'
+$ xa '"Hello" >> CHAR_CODES >> CHAR_CODESD'
 # Hello
 ```
 

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -534,21 +534,29 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CHAR_CODED(charCode: INT): STRING`
 
+`CHAR_CODES(string: STRING): STREAM<INT>`
+
+`CHAR_CODESD(charCodes: STREAM<INT>): STRING`
+
 These functions convert between strings and character codes.
 
 The `CHAR_CODE` family works in UTF-16 code units.
 
 Functions with the `D` suffix decode, while those without it encode.
 
-| Function     | Pre-decode type | Pre-decode meaning | Direction   | Post-decode type | Post-decode meaning          |
-|--------------|-----------------|--------------------|-------------|------------------|------------------------------|
-| `CHAR_CODE`  | `INT`           | code unit value    | ← to code   | `STRING`         | exactly one UTF-16 code unit |
-| `CHAR_CODED` | `INT`           | code unit value    | → to string | `STRING`         | exactly one UTF-16 code unit |
+| Function      | Pre-decode type | Pre-decode meaning      | Direction   | Post-decode type | Post-decode meaning          |
+|---------------|-----------------|-------------------------|-------------|------------------|------------------------------|
+| `CHAR_CODE`   | `INT`           | code unit value         | ← to code   | `STRING`         | exactly one UTF-16 code unit |
+| `CHAR_CODED`  | `INT`           | code unit value         | → to string | `STRING`         | exactly one UTF-16 code unit |
+| `CHAR_CODES`  | `STREAM<INT>`   | value of each code unit | ← to code   | `STRING`         | string                       |
+| `CHAR_CODESD` | `STREAM<INT>`   | value of each code unit | → to string | `STRING`         | string                       |
 
 An error is raised for inputs that fall under any of the following:
 
-- `CHAR_CODED`: given a value that is not between 0 and 65535
+- `CHAR_CODED` / `CHAR_CODESD`: given a value that is not between 0 and 65535
 - `CHAR_CODE`: given a string that does not consist of exactly one code unit
+
+For `CHAR_CODESD`, which takes a stream, the numeric condition is checked for each element.
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -562,6 +570,15 @@ $ xa 'CHAR_CODED(65)'
 
 $ xa 'CHAR_CODED(12354)'
 # あ
+
+$ xa 'JSONS(TO_ARRAY(CHAR_CODES("ABC")))'
+# [65,66,67]
+
+$ xa 'CHAR_CODESD(65, 66, 67)'
+# ABC
+
+$ xa 'CHAR_CODESD(CHAR_CODES("Hello"))'
+# Hello
 ```
 
 ## `UC` Convert to Uppercase

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -553,10 +553,8 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 次のいずれかに該当する入力に対しては、エラーになります。
 
-- `CHAR_CODED`・`CHAR_CODESD`: 0以上65535以下でない数値を与えた場合
+- `CHAR_CODED` `CHAR_CODESD`: 0以上65535以下でない数値を与えた場合
 - `CHAR_CODE`: コード単位が丁度1個でない文字列を与えた場合
-
-ストリームを受け取る `CHAR_CODESD` では、数値に関する条件は各要素について判定されます。
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -571,13 +569,13 @@ $ xa 'CHAR_CODED(65)'
 $ xa 'CHAR_CODED(12354)'
 # あ
 
-$ xa 'JSONS(TO_ARRAY(CHAR_CODES("ABC")))'
-# [65,66,67]
+$ xa 'CHAR_CODES("ABC") >> JOIN[","]'
+# 65,66,67
 
 $ xa 'CHAR_CODESD(65, 66, 67)'
 # ABC
 
-$ xa 'CHAR_CODESD(CHAR_CODES("Hello"))'
+$ xa '"Hello" >> CHAR_CODES >> CHAR_CODESD'
 # Hello
 ```
 

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -534,21 +534,29 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CHAR_CODED(charCode: INT): STRING`
 
+`CHAR_CODES(string: STRING): STREAM<INT>`
+
+`CHAR_CODESD(charCodes: STREAM<INT>): STRING`
+
 文字列と文字コードを相互に変換します。
 
 `CHAR_CODE` 系はUTF-16コード単位を単位とします。
 
 末尾に `D` が付く関数はデコード、付かない関数はエンコードに対応します。
 
-| 関数           | デコード前の型 | デコード前の意味 | 変換方向   | デコード後の型  | デコード後の意味         |
-|--------------|---------|----------|--------|----------|------------------|
-| `CHAR_CODE`  | `INT`   | コード単位の数値 | ← コード化 | `STRING` | 丁度1個のUTF-16コード単位 |
-| `CHAR_CODED` | `INT`   | コード単位の数値 | → 文字列化 | `STRING` | 丁度1個のUTF-16コード単位 |
+| 関数          | デコード前の型 | デコード前の意味   | 変換方向   | デコード後の型 | デコード後の意味          |
+|---------------|----------------|--------------------|------------|----------------|---------------------------|
+| `CHAR_CODE`   | `INT`          | コード単位の数値   | ← コード化 | `STRING`       | 丁度1個のUTF-16コード単位 |
+| `CHAR_CODED`  | `INT`          | コード単位の数値   | → 文字列化 | `STRING`       | 丁度1個のUTF-16コード単位 |
+| `CHAR_CODES`  | `STREAM<INT>`  | 各コード単位の数値 | ← コード化 | `STRING`       | 文字列                    |
+| `CHAR_CODESD` | `STREAM<INT>`  | 各コード単位の数値 | → 文字列化 | `STRING`       | 文字列                    |
 
 次のいずれかに該当する入力に対しては、エラーになります。
 
-- `CHAR_CODED`: 0以上65535以下でない数値を与えた場合
+- `CHAR_CODED`・`CHAR_CODESD`: 0以上65535以下でない数値を与えた場合
 - `CHAR_CODE`: コード単位が丁度1個でない文字列を与えた場合
+
+ストリームを受け取る `CHAR_CODESD` では、数値に関する条件は各要素について判定されます。
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -562,6 +570,15 @@ $ xa 'CHAR_CODED(65)'
 
 $ xa 'CHAR_CODED(12354)'
 # あ
+
+$ xa 'JSONS(TO_ARRAY(CHAR_CODES("ABC")))'
+# [65,66,67]
+
+$ xa 'CHAR_CODESD(65, 66, 67)'
+# ABC
+
+$ xa 'CHAR_CODESD(CHAR_CODES("Hello"))'
+# Hello
 ```
 
 ## `UC` 大文字に変換

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -41,6 +41,32 @@ fun createStringMounts(): List<Map<String, Mount>> {
             if (code < 0 || code > 0xFFFF) throw FluoriteException("Argument must be between 0 and 65535, got $code".toFluoriteString())
             code.toChar().toString().toFluoriteString()
         },
+        "CHAR_CODES" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("CHAR_CODES(string: STRING): STREAM<INT>")
+            val string = arguments[0].toFluoriteString(null).value
+            FluoriteStream {
+                for (char in string) {
+                    emit(FluoriteInt(char.code))
+                }
+            }
+        },
+        "CHAR_CODESD" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("CHAR_CODESD(charCodes: STREAM<INT>): STRING")
+            val value = arguments[0]
+            val sb = StringBuilder()
+            suspend fun appendCode(item: FluoriteValue) {
+                val number = item.toFluoriteNumber(null)
+                val code = number.roundToInt()
+                if (code < 0 || code > 0xFFFF) throw FluoriteException("Each element must be between 0 and 65535, got $code".toFluoriteString())
+                sb.append(code.toChar())
+            }
+            if (value is FluoriteStream) {
+                value.collect { item -> appendCode(item) }
+            } else {
+                appendCode(value)
+            }
+            sb.toString().toFluoriteString()
+        },
 
         *run {
             fun create(signature: String): FluoriteFunction {

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -59,7 +59,9 @@ fun createStringMounts(): List<Map<String, Mount>> {
                 sb.append(code.toChar())
             }
             if (value is FluoriteStream) {
-                value.collect { item -> appendCode(item) }
+                value.collect { item ->
+                    appendCode(item)
+                }
             } else {
                 appendCode(value)
             }

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -36,8 +36,7 @@ fun createStringMounts(): List<Map<String, Mount>> {
         },
         "CHAR_CODED" define FluoriteFunction.immediate { arguments ->
             if (arguments.size != 1) usage("CHAR_CODED(charCode: INT): STRING")
-            val number = arguments[0].toFluoriteNumber(null)
-            val code = number.roundToInt()
+            val code = arguments[0].toFluoriteNumber(null).roundToInt()
             if (code < 0 || code > 0xFFFF) throw FluoriteException("Argument must be between 0 and 65535, got $code".toFluoriteString())
             code.toChar().toString().toFluoriteString()
         },
@@ -45,7 +44,7 @@ fun createStringMounts(): List<Map<String, Mount>> {
             if (arguments.size != 1) usage("CHAR_CODES(string: STRING): STREAM<INT>")
             val string = arguments[0].toFluoriteString(null).value
             FluoriteStream {
-                for (char in string) {
+                string.forEach { char ->
                     emit(FluoriteInt(char.code))
                 }
             }
@@ -55,8 +54,7 @@ fun createStringMounts(): List<Map<String, Mount>> {
             val value = arguments[0]
             val sb = StringBuilder()
             suspend fun appendCode(item: FluoriteValue) {
-                val number = item.toFluoriteNumber(null)
-                val code = number.roundToInt()
+                val code = item.toFluoriteNumber(null).roundToInt()
                 if (code < 0 || code > 0xFFFF) throw FluoriteException("Each element must be between 0 and 65535, got $code".toFluoriteString())
                 sb.append(code.toChar())
             }

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -151,5 +151,28 @@ class StringMountsTest {
         // CHAR_CODED: 範囲外の場合はエラー
         assertFailsWith<FluoriteException> { eval("CHAR_CODED(-1)") } // 負数はエラー
         assertFailsWith<FluoriteException> { eval("CHAR_CODED(65536)") } // 65536はエラー
+
+        // CHAR_CODES: 文字列からUTF-16コード単位のストリームを返す
+        assertEquals("65,66,67", eval("CHAR_CODES('ABC')").stream()) // 'ABC'のコード列
+        assertEquals("12354,12356", eval("CHAR_CODES('\u3042\u3044')").stream()) // 'あい'のコード列
+        assertEquals("", eval("CHAR_CODES('')").stream()) // 空文字列は空ストリーム
+        // サロゲートペア（U+1F370 🍰）は2つのコード単位（55356, 57200）に分解される
+        assertEquals("55356,57200", eval("CHAR_CODES('\uD83C\uDF70')").stream())
+
+        // CHAR_CODESD: コード単位のストリームから文字列を返す
+        assertEquals("ABC", eval("CHAR_CODESD(65, 66, 67)").string) // コード列から文字列
+        assertEquals("\u3042\u3044", eval("CHAR_CODESD(12354, 12356)").string) // 日本語文字
+        assertEquals("A", eval("CHAR_CODESD(65)").string) // 単一のコード単位
+        // サロゲートペアのコード単位から文字列を返す
+        assertEquals("\uD83C\uDF70", eval("CHAR_CODESD(55356, 57200)").string) // 🍰
+
+        // CHAR_CODESD: 範囲外の場合はエラー
+        assertFailsWith<FluoriteException> { eval("CHAR_CODESD(-1)") } // 負数はエラー
+        assertFailsWith<FluoriteException> { eval("CHAR_CODESD(65536)") } // 65536はエラー
+
+        // CHAR_CODESとCHAR_CODESDは逆変換
+        assertEquals("Hello", eval("'Hello' >> CHAR_CODES >> CHAR_CODESD").string)
+        // サロゲートペアも往復できる
+        assertEquals("\uD83C\uDF70", eval("'\uD83C\uDF70' >> CHAR_CODES >> CHAR_CODESD").string)
     }
 }


### PR DESCRIPTION
Claude Fairyは https://github.com/MirrgieRiana/private/issues/16 に記載の Protocol 103F 必読なのだ

## 実装内容なのだ

文字列と、その各文字のUTF-16コード単位の数値ストリームとを相互に変換する、以下の2つの組み込み関数を追加するのだ〜♪

- `CHAR_CODES(string: STRING): STREAM<INT>` — 文字列の各UTF-16コード単位の数値を、ストリームで返すのだ
- `CHAR_CODESD(charCodes: STREAM<INT>): STRING` — UTF-16コード単位の数値ストリームから、文字列を組み立てるのだ

## 背景なのだ

[PR MirrgieRiana/xarpite#540](https://github.com/MirrgieRiana/xarpite/pull/540) は `CHAR_CODE` 系・`CODE_POINT` 系の合計8関数を一括で追加するものだったのだけど、レビューの負荷が大きくなりすぎたのだ。そこで [PR MirrgieRiana/xarpite#575](https://github.com/MirrgieRiana/xarpite/pull/575) で `CHAR_CODE` / `CHAR_CODED` を先行して切り出したのに続き、コード量の多い `CHAR_CODES` / `CHAR_CODESD` の2関数だけを切り出して、最新の `main` を起点に移植したのが、このPRなのだ〜。

ドキュメントは、PR MirrgieRiana/xarpite#575 が整えた表形式のまま、`CHAR_CODE` 系の行として2関数分を追記しているのだ。

## 変更ファイルなのだ

- `src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt` — 実装なのだ
- `src/commonTest/kotlin/StringMountsTest.kt` — テストなのだ
- `pages/docs/ja/string.md` — 日本語ドキュメントなのだ
- `pages/docs/en/string.md` — 英語ドキュメントなのだ
- `changelog.d/add-char-codes-functions.md` — 更新履歴の断片なのだ