### PR TITLE
executeProcess の戻り値を ByteArray にするリファクタリング

### DIFF
--- a/src/commonMain/kotlin/mirrg/xarpite/RuntimeContext.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/RuntimeContext.kt
@@ -98,7 +98,7 @@ interface IoContext {
     suspend fun readBytesFromStdin(): ByteArray?
     suspend fun writeBytesToStdout(bytes: ByteArray)
     suspend fun writeBytesToStderr(bytes: ByteArray)
-    suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): String
+    suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): ByteArray
     suspend fun fetch(context: RuntimeContext, url: String): Result<ByteArray>
     fun exit(code: Int): Nothing
 }
@@ -112,7 +112,7 @@ open class UnsupportedIoContext : IoContext {
     override suspend fun readBytesFromStdin(): ByteArray? = throw UnsupportedOperationException()
     override suspend fun writeBytesToStdout(bytes: ByteArray): Unit = throw UnsupportedOperationException()
     override suspend fun writeBytesToStderr(bytes: ByteArray): Unit = throw UnsupportedOperationException()
-    override suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): String = throw UnsupportedOperationException()
+    override suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): ByteArray = throw UnsupportedOperationException()
     override suspend fun fetch(context: RuntimeContext, url: String): Result<ByteArray> = throw UnsupportedOperationException()
     override fun exit(code: Int): Nothing = throw UnsupportedOperationException()
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliMounts.kt
@@ -235,7 +235,7 @@ fun createCliMounts(args: List<String>): List<Map<String, Mount>> {
 
                     val process = commandList[0]
                     val processArgs = commandList.drop(1)
-                    val output = context.io.executeProcess(process, processArgs, env)
+                    val output = context.io.executeProcess(process, processArgs, env).decodeToString()
 
                     val lines = output.lines()
                     val nonEmptyLines = if (lines.isNotEmpty() && lines.last().isEmpty()) {
@@ -267,7 +267,7 @@ fun createCliMounts(args: List<String>): List<Map<String, Mount>> {
 
             // bash -c script arg0 arg1 ... の場合、arg0が$0、arg1が$1になるため、
             // ダミーの$0として"bash"を挿入
-            val output = context.io.executeProcess("bash", listOf("-c", script, "bash", *args), emptyMap())
+            val output = context.io.executeProcess("bash", listOf("-c", script, "bash", *args), emptyMap()).decodeToString()
 
             val result = when {
                 output.endsWith("\r\n") -> output.dropLast(2)

--- a/src/commonTest/kotlin/CliTest.kt
+++ b/src/commonTest/kotlin/CliTest.kt
@@ -2594,7 +2594,8 @@ internal class TestIoContext(
     }
 
     override suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>) =
-        executeProcessHandler?.invoke(process, args, env) ?: throw UnsupportedOperationException("executeProcessHandler is not set")
+        // ハンドラはプロセスの標準出力をStringとして模擬するため、実プラットフォームと同様にByteArrayへエンコードして返す
+        (executeProcessHandler?.invoke(process, args, env) ?: throw UnsupportedOperationException("executeProcessHandler is not set")).encodeToByteArray()
 
     override suspend fun fetch(context: RuntimeContext, url: String): Result<ByteArray> =
         fetchHandler?.invoke(context, url) ?: throw UnsupportedOperationException("fetchHandler is not set")

--- a/src/jvmMain/kotlin/mirrg/xarpite/Platform.kt
+++ b/src/jvmMain/kotlin/mirrg/xarpite/Platform.kt
@@ -39,7 +39,7 @@ suspend fun writeBytesToStderr(bytes: ByteArray) = withContext(Dispatchers.IO) {
     System.err.flush()
 }
 
-suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): String = coroutineScope {
+suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): ByteArray = coroutineScope {
     withContext(Dispatchers.IO) {
         val commandList = listOf(process) + args
         val processBuilder = ProcessBuilder(commandList)
@@ -56,9 +56,7 @@ suspend fun executeProcess(process: String, args: List<String>, env: Map<String,
         try {
             // 標準出力を非同期で読み取る
             val outputDeferred = async {
-                BufferedReader(processInstance.inputStream.reader()).use { reader ->
-                    reader.readText()
-                }
+                processInstance.inputStream.use { it.readBytes() }
             }
 
             // 標準エラー出力を非同期で読み取り、Xarpiteのstderrに転送

--- a/src/jvmTest/kotlin/mirrg/xarpite/cli/IncUrlKtorTest.kt
+++ b/src/jvmTest/kotlin/mirrg/xarpite/cli/IncUrlKtorTest.kt
@@ -258,7 +258,7 @@ class IncUrlKtorTest {
             override suspend fun readBytesFromStdin(): ByteArray? = null
             override suspend fun writeBytesToStdout(bytes: ByteArray) {}
             override suspend fun writeBytesToStderr(bytes: ByteArray) {}
-            override suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): String {
+            override suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): ByteArray {
                 throw UnsupportedOperationException("executeProcess is not supported in test")
             }
             override suspend fun fetch(context: RuntimeContext, url: String): Result<ByteArray> {

--- a/src/linuxX64Main/kotlin/mirrg/xarpite/Platform.kt
+++ b/src/linuxX64Main/kotlin/mirrg/xarpite/Platform.kt
@@ -101,7 +101,7 @@ private fun setNonBlocking(fd: Int, name: String) {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): String = withContext(Dispatchers.IO) {
+suspend fun executeProcess(process: String, args: List<String>, env: Map<String, String?>): ByteArray = withContext(Dispatchers.IO) {
     memScoped {
         // パイプを作成（標準出力用と標準エラー出力用）
         val stdoutPipe = allocArray<IntVar>(2)
@@ -436,7 +436,7 @@ suspend fun executeProcess(process: String, args: List<String>, env: Map<String,
                     }
                 }
 
-                // ByteArrayのchunkを連結して文字列に変換
+                // ByteArrayのchunkを連結する
                 // 事前に総サイズを算出して1回だけByteArrayを確保し、copyIntoで詰めることでO(n^2)を回避
                 val outputSize = outputChunks.sumOf { it.size }
                 val outputBytes = ByteArray(outputSize)
@@ -445,7 +445,7 @@ suspend fun executeProcess(process: String, args: List<String>, env: Map<String,
                     chunk.copyInto(outputBytes, outputOffset)
                     outputOffset += chunk.size
                 }
-                outputBytes.decodeToString()
+                outputBytes
             } finally {
                 // close()が失敗してもtryブロックの例外をマスクしないようにする
                 try {

--- a/src/linuxX64Main/kotlin/mirrg/xarpite/Platform.kt
+++ b/src/linuxX64Main/kotlin/mirrg/xarpite/Platform.kt
@@ -436,7 +436,7 @@ suspend fun executeProcess(process: String, args: List<String>, env: Map<String,
                     }
                 }
 
-                // ByteArrayのchunkを連結する
+                // ByteArrayのchunkを連結
                 // 事前に総サイズを算出して1回だけByteArrayを確保し、copyIntoで詰めることでO(n^2)を回避
                 val outputSize = outputChunks.sumOf { it.size }
                 val outputBytes = ByteArray(outputSize)


### PR DESCRIPTION
## 概要

`IoContext.executeProcess` の戻り値を `String` から `ByteArray` へ変更する単機能リファクタリングです。

これは EXECB（[Issue MirrgieRiana/xarpite#480](https://github.com/MirrgieRiana/xarpite/issues/480)）の実装を見据えた下準備で、[この議論](https://github.com/MirrgieRiana/xarpite/issues/480#issuecomment-4716277230)に基づいています。下層が生の `ByteArray` を返すようになることで、後続の `EXECB`（標準出力を単一 BLOB で返す）が文字列を経由せず素直に書けるようになります。

本 PR の範囲は `executeProcess` のシグネチャ変更とそれに伴う追従のみで、`EXECB` 本体の追加は含みません。

## 変更内容

- `IoContext.executeProcess` の戻り値を `ByteArray` に変更
- Native / JVM の各プラットフォーム実装を `ByteArray` 返しに変更
- 呼び出し側（`EXEC` / `EXECL` / `BASH`）で `decodeToString()` して従来どおり文字列として扱う
- テストのモック実装を追従

## 補足

JVM 実装はこれまで標準出力をプラットフォーム既定の文字コードで読んでいましたが、本変更により生バイトを読んで `decodeToString()`（UTF-8）するようになり、Native 実装と文字コードの扱いが揃います。既定文字コードが UTF-8 でない環境では `EXEC` / `BASH` の出力デコードの挙動が変わりますが、ユーザー可視の振る舞い変化はないものとみなし、CHANGELOG 断片は空としています。要否についてご判断いただけると嬉しいのだっ🌱