### PR TITLE
キーゲッター引数名を `keyGetter` に統一するのだ

### DIFF
--- a/pages/docs/en/builtin.md
+++ b/pages/docs/en/builtin.md
@@ -756,9 +756,9 @@ $ xa '1 .. 9 >> SORT[a, b -> a % 3 <=> b % 3] >> JOIN[" "]'
 
 ### Sort by Key Getter Function
 
-`SORT(by: key_getter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
+`SORT(by: keyGetter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
 
-If the first argument is a `by` parameter, applies the `key_getter` function to each element of the second argument, compares the results, and sorts.
+If the first argument is a `by` parameter, applies the `keyGetter` function to each element of the second argument, compares the results, and sorts.
 
 The following example sorts by the remainder when dividing each element by 3.
 
@@ -773,7 +773,7 @@ $ xa '1 .. 9 >> SORT[by: x -> x % 3] >> JOIN[" "]'
 
 `SORTR(comparator: VALUE, VALUE -> INT; stream: STREAM<VALUE>): STREAM<VALUE>`
 
-`SORTR(by: key_getter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
+`SORTR(by: keyGetter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
 
 Sorts a stream in descending order.
 

--- a/pages/docs/ja/builtin.md
+++ b/pages/docs/ja/builtin.md
@@ -616,9 +616,9 @@ $ xa '1 .. 9 >> SORT[a, b -> a % 3 <=> b % 3] >> JOIN[" "]'
 
 ### キー取得関数によるソート
 
-`SORT(by: key_getter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
+`SORT(by: keyGetter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
 
-第1引数が `by` パラメータである場合、第2引数の各要素に対して `key_getter` 関数を適用し、その結果を比較してソートします。
+第1引数が `by` パラメータである場合、第2引数の各要素に対して `keyGetter` 関数を適用し、その結果を比較してソートします。
 
 以下の例では、各要素を3で割った余りでソートしています。
 
@@ -633,7 +633,7 @@ $ xa '1 .. 9 >> SORT[by: x -> x % 3] >> JOIN[" "]'
 
 `SORTR(comparator: VALUE, VALUE -> INT; stream: STREAM<VALUE>): STREAM<VALUE>`
 
-`SORTR(by: key_getter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
+`SORTR(by: keyGetter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>`
 
 ストリームを降順にソートします。
 

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
@@ -536,7 +536,7 @@ fun createStreamMounts(): List<Map<String, Mount>> {
                             stream
                         }
                     }
-                    run { // SORT(by: key_getter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>
+                    run { // SORT(by: keyGetter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>
                         if (arguments.size != 2) return@run
                         val entry = arguments[0]
                         if (entry !is FluoriteArray) return@run
@@ -567,7 +567,7 @@ fun createStreamMounts(): List<Map<String, Mount>> {
                     usage(
                         "$name(stream: STREAM<VALUE>): STREAM<VALUE>",
                         "$name(comparator: VALUE, VALUE -> INT; stream: STREAM<VALUE>): STREAM<VALUE>",
-                        "$name(by: key_getter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>",
+                        "$name(by: keyGetter: VALUE -> VALUE; stream: STREAM<VALUE>): STREAM<VALUE>",
                     )
                 }
             }


### PR DESCRIPTION
ドキュメントのシグネチャ表記で揺れている `key_getter`（snake_case）を、リポジトリ多数派の `keyGetter`（camelCase）に統一するのだ。

`DISTINCT` / `GROUP` のキーゲッター引数は `keyGetter` 表記なのに対し、`SORT` / `SORTR` のみ古い `key_getter` 表記が残っていたのだっ。これは単なる非一貫性で、古い記法が残っていただけのものなのだ。

## 変更内容

- `pages/docs/ja/builtin.md` / `pages/docs/en/builtin.md` の `SORT` / `SORTR` のシグネチャと説明文中の `key_getter` を `keyGetter` に統一
- `SORT` / `SORTR` の実装が出力する usage メッセージ（`StreamMounts.kt`）内の `key_getter` 表記も合わせて統一

## 文脈

型文化（シグネチャ正書法）の規範化を進める Issue #588 の議論に基づくのだ。
詳細: https://github.com/MirrgieRiana/xarpite/issues/588#issuecomment-4725910753