### PR TITLE
タプル意味論の配列型を角括弧表記 `[A; B]` に統一するのだ

### DIFF
--- a/pages/docs/en/builtin.md
+++ b/pages/docs/en/builtin.md
@@ -1090,7 +1090,7 @@ $ xa 'TO_ARRAY(1 .. 3)'
 
 ## `TO_OBJECT` Convert Stream of Entries to Object
 
-`OBJECT(stream: STREAM<ARRAY<STRING; VALUE>>): OBJECT`
+`OBJECT(stream: STREAM<[STRING; VALUE]>): OBJECT`
 
 Converts each element of the first argument stream into an object as entries.
 

--- a/pages/docs/ja/builtin.md
+++ b/pages/docs/ja/builtin.md
@@ -931,7 +931,7 @@ $ xa 'TO_ARRAY(1 .. 3)'
 
 ## `TO_OBJECT` エントリーのストリームをオブジェクトに変換
 
-`OBJECT(stream: STREAM<ARRAY<STRING; VALUE>>): OBJECT`
+`OBJECT(stream: STREAM<[STRING; VALUE]>): OBJECT`
 
 第1引数のストリームの各要素をエントリーとしてオブジェクトに変換します。
 

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/ConvertMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/ConvertMounts.kt
@@ -53,7 +53,7 @@ fun createConvertMounts(): List<Map<String, Mount>> {
             if (arguments.size == 1) {
                 FluoriteObject.fromStream(arguments[0])
             } else {
-                usage("TO_OBJECT(stream: STREAM<ARRAY<STRING; VALUE>>): OBJECT")
+                usage("TO_OBJECT(stream: STREAM<[STRING; VALUE]>): OBJECT")
             }
         },
     ).let { listOf(it) }


### PR DESCRIPTION
タプル意味論を持つ配列の型表記を、最新の正書法である角括弧表記 `[A; B]` に統一するのだ。

これまで均質な配列の `ARRAY<T>` と、タプル意味論の配列の `[A; B]` の書き分けが正書法として定まっているが、一部に旧表記 `ARRAY<A; B>` が残っているのだ。これを `[A; B]` に揃えるのだっ。

## 変更内容

`TO_OBJECT` のシグネチャに残っていた `STREAM<ARRAY<STRING; VALUE>>` を `STREAM<[STRING; VALUE]>` に統一するのだ。

- `pages/docs/ja/builtin.md` / `pages/docs/en/builtin.md` の `TO_OBJECT` のシグネチャ
- `ConvertMounts.kt` の `TO_OBJECT` の usage メッセージ

## 背景

型文化の調査の場である [Issue #588](https://github.com/MirrgieRiana/xarpite/issues/588#issuecomment-4727175087) の議論に基づくのだ。
