### PR TITLE
Maven Central をデフォルトの `INC` に追加する

### DIFF
--- a/changelog.d/add-maven-central-default-inc.md
+++ b/changelog.d/add-maven-central-default-inc.md
@@ -1,0 +1,1 @@
+Added Maven Central to the default `INC` paths for module search.

--- a/pages/docs/en/cli.md
+++ b/pages/docs/en/cli.md
@@ -427,7 +427,7 @@ Strings starting with `http://` or `https://` are interpreted as URLs.
 
 When a relative directory path is specified, it is resolved based on `PWD`.
 
-By default, `./.xarpite/lib` and `./.xarpite/maven` are included.
+By default, `./.xarpite/lib`, `./.xarpite/maven`, and Maven Central (`https://repo1.maven.org/maven2`) are included.
 
 ---
 

--- a/pages/docs/ja/cli.md
+++ b/pages/docs/ja/cli.md
@@ -427,7 +427,7 @@ $ FOO=bar xa 'ENV.FOO'
 
 相対ディレクトリパスを指定した場合、そのパスは `PWD` に基づいて解決されます。
 
-デフォルトでは `./.xarpite/lib` と `./.xarpite/maven` が含まれています。
+デフォルトでは `./.xarpite/lib`、`./.xarpite/maven`、および Maven Central (`https://repo1.maven.org/maven2`) が含まれています。
 
 ---
 

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
@@ -171,6 +171,7 @@ fun showVersion(ioContext: IoContext) {
 }
 
 fun RuntimeContext.addDefaultIncPaths() {
+    inc.values += "https://repo1.maven.org/maven2".toFluoriteString()
     inc.values += "./.xarpite/maven".toFluoriteString()
     inc.values += "./.xarpite/lib".toFluoriteString()
 }

--- a/src/commonTest/kotlin/CliTest.kt
+++ b/src/commonTest/kotlin/CliTest.kt
@@ -1013,10 +1013,11 @@ class CliTest {
     @Test
     fun incContainsDefaultPaths() = runTest {
         val context = TestIoContext()
-        // デフォルトで ./.xarpite/lib と ./.xarpite/maven が含まれている
+        // デフォルトで ./.xarpite/lib、./.xarpite/maven、Maven Central が含まれている
         val incArray = cliEval(context, "INC").array()
         assertTrue("./.xarpite/lib" in incArray)
         assertTrue("./.xarpite/maven" in incArray)
+        assertTrue("https://repo1.maven.org/maven2" in incArray)
     }
 
     @Test
@@ -1033,6 +1034,7 @@ class CliTest {
         val incStrings = capturedInc!!.map { it.toFluoriteString(null).value }
         assertTrue("./.xarpite/lib" in incStrings)
         assertTrue("./.xarpite/maven" in incStrings)
+        assertTrue("https://repo1.maven.org/maven2" in incStrings)
     }
 
     @Test
@@ -2681,7 +2683,8 @@ internal class TestIoContext(
         (executeProcessHandler?.invoke(process, args, env) ?: throw UnsupportedOperationException("executeProcessHandler is not set")).encodeToByteArray()
 
     override suspend fun fetch(context: RuntimeContext, url: String): Result<ByteArray> =
-        fetchHandler?.invoke(context, url) ?: throw UnsupportedOperationException("fetchHandler is not set")
+        // fetchHandler 未設定時は、デフォルトの INC に含まれる Maven Central のような URL の取得失敗を模擬する
+        fetchHandler?.invoke(context, url) ?: Result.failure(UnsupportedOperationException("fetchHandler is not set"))
 
     override fun getEnv(): Map<String, String> = env
 

--- a/src/jvmTest/kotlin/mirrg/xarpite/cli/IncUrlKtorTest.kt
+++ b/src/jvmTest/kotlin/mirrg/xarpite/cli/IncUrlKtorTest.kt
@@ -93,6 +93,25 @@ class IncUrlKtorTest {
     }
 
     @Test
+    fun mavenCoordinateFromDefaultMavenCentral() = runTest {
+        // デフォルトのINCに含まれるMaven Centralを起点に座標が解決されることを確認
+        val io = createTestIoContext { _, url ->
+            if (url == "https://repo1.maven.org/maven2/com/example/mylib/1.0.0/mylib-1.0.0.xa1") {
+                Result.success("\"Module from Maven Central\"".encodeToByteArray())
+            } else {
+                Result.failure(RuntimeException("Not found: $url"))
+            }
+        }
+
+        // INCへの追加なしで、デフォルトのMaven Centralから座標を解決
+        val result = cliEval(io, """
+            USE("com.example:mylib:1.0.0")
+        """.trimIndent()).toFluoriteString(null).value
+
+        assertEquals("Module from Maven Central", result)
+    }
+
+    @Test
     fun httpUrlWithTrailingSlashNormalization() = runTest {
         withKtorServer { server ->
             // 末尾スラッシュがあるINCパスでもモジュールをロードできることを確認


### PR DESCRIPTION
## 趣旨

デフォルトの `INC`（モジュール検索パスの配列）に **Maven Central** (`https://repo1.maven.org/maven2`) を追加します。

これにより、`USE("group:artifact:version")` のような Maven 座標が、追加設定なしで Maven Central から `.xa1` モジュールを解決できるようになります。

## 背景

[#590](https://github.com/MirrgieRiana/xarpite/issues/590) 本来のテーマであり、[#516](https://github.com/MirrgieRiana/xarpite/issues/516) での長い議論の末、Xarpite 自身が Kotlin Multiplatform 製で `mavenCentral()` を利用する正規の消費者であることから、座標で `.xa1` を取得するのは妥当な OSS 利用であるという結論に至りました。

## 変更内容

- `addDefaultIncPaths`（`CliUtil.kt`）の **先頭** に Maven Central の URL を追加
  - URL エントリは常にローカルパスエントリの後に判定されるため、Central は最弱のフォールバックとして機能します。
- ドキュメント（`pages/docs/ja/cli.md` / `pages/docs/en/cli.md`）のデフォルトパス記述を更新
- 関連テストを追加・更新

Closes #590
