### PR TITLE
ルートのJSテストの mocha タイムアウトを `node` / `browser` に揃えるのだ。

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,13 @@ kotlin {
 
     jvm()
     js {
-        nodejs()
+        nodejs {
+            testTask {
+                useMocha {
+                    timeout = "10s"
+                }
+            }
+        }
         binaries.library()
         outputModuleName = "xarpite-core"
         compilerOptions {


### PR DESCRIPTION
PR #579 の CI 失敗調査の過程で見つかった、PR #579 とは無関係な偶発的テスト失敗への対処として派生した新規 PR なのだ。文脈は https://github.com/MirrgieRiana/xarpite/pull/579#issuecomment-4737132192 を参照なのだ。

## 趣旨なのだ

ルートプロジェクトの `:jsNodeTest` が、混雑時に mocha の既定タイムアウト 2 秒を偶発的に踏み抜いて失敗することがある問題を緩和するのだ。ルートの `build.gradle.kts` の `js { nodejs() }` ブロックに、サブプロジェクト `node` / `browser` と同じ `useMocha { timeout = "10s" }` を追加して揃えるのだ。

## 背景なのだ

ローカルで `build` を実行した際、`mirrg.xarpite.js.test.JsTest.property[js, node]` が `Timeout of 2000ms exceeded` で偶発的に失敗したのだ。このテストはルートプロジェクトの `src/jsTest` に属するのだが、ルートの `nodejs()` には mocha のタイムアウト指定が無く、mocha の既定値 2 秒のまま走っていたのだ。一方で `node/build.gradle.kts` と `browser/build.gradle.kts` は既に `10s` に延ばしてあるのだ。テスト自体は JS エンジンを起動して値を読み書きするだけの軽い内容で、本質的に 2 秒以上かかるものではなく、マシンが混雑した瞬間に偶発的に上限を踏み抜いたものと見られるのだ。

なお、これはタイムアウトの余裕を増やす緩和であって、テストが恒常的に重くなった場合は別途の対処が必要になるのだ。

## 変更ファイルなのだ

- `build.gradle.kts` — ルートの `nodejs()` に `useMocha { timeout = "10s" }` を追加するのだ