### PR TITLE
xa の終了前に HTTP クライアントの close 完了を待つようにするのだ

### DIFF
--- a/changelog.d/await-http-client-close-on-exit.md
+++ b/changelog.d/await-http-client-close-on-exit.md
@@ -1,0 +1,1 @@
+?Fixed a possible crash on exit after making HTTPS requests in the native build.

--- a/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
@@ -2,6 +2,7 @@ package mirrg.xarpite
 
 import io.github.mirrgieriana.xarpeg.parseAll
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
@@ -81,6 +82,8 @@ suspend fun <T> CoroutineScope.withEvaluator(ioContext: IoContext, block: suspen
             }
         }
     } finally {
-        daemonScope.coroutineContext.job.cancelAndJoin()
+        withContext(NonCancellable) {
+            daemonScope.coroutineContext.job.cancelAndJoin()
+        }
     }
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
@@ -3,8 +3,9 @@ package mirrg.xarpite
 import io.github.mirrgieriana.xarpeg.parseAll
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import mirrg.xarpite.compilers.compileToGetter
 import mirrg.xarpite.compilers.compileToRunner
@@ -80,6 +81,6 @@ suspend fun <T> CoroutineScope.withEvaluator(ioContext: IoContext, block: suspen
             }
         }
     } finally {
-        daemonScope.cancel()
+        daemonScope.coroutineContext.job.cancelAndJoin()
     }
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/RuntimeContext.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/RuntimeContext.kt
@@ -2,8 +2,11 @@ package mirrg.xarpite
 
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import mirrg.kotlin.helium.Single
 import mirrg.kotlin.helium.atLeast
 import mirrg.kotlin.helium.atMost
@@ -24,7 +27,10 @@ class RuntimeContext(
             try {
                 awaitCancellation()
             } finally {
-                httpClient.close()
+                withContext(NonCancellable) {
+                    httpClient.close()
+                    httpClient.coroutineContext.job.join()
+                }
             }
         }
         httpClient


### PR DESCRIPTION
PR #600 のネイティブ SIGSEGV 調査から派生した新規 PR なのだ。文脈は https://github.com/MirrgieRiana/xarpite/pull/600#issuecomment-4738491669 を参照なのだ。

## 趣旨なのだ

`xa`（およびテストランナー）の終了前に、HTTP クライアントの close 完了を待つようにするのだ。これにより、プロセス終了時の `atexit` の `OPENSSL_cleanup` と、curl の接続終了処理が並走する窓を狭めるのだ。

## 背景なのだ

PR #600 でのネイティブクラッシュ調査（コアダンプ解析・ソース追跡）の結果、`:linuxX64Test` で稀に発生していた SIGSEGV (exit 139) は、深い再帰によるスタック枯渇ではなく、**プロセス終了時に OpenSSL のグローバル後始末（`OPENSSL_cleanup`）と curl の接続終了スレッドの解放処理が競合した use-after-free** に見えることが分かったのだ。

`linuxX64Main` は Ktor の Curl エンジン（OpenSSL/libcurl 静的リンク）を使うのだ。これまでの後始末は `daemonScope.cancel()` で close を「撃ちっぱなし」にしていて、`httpClient.close()` の完了を待たずに `main` を抜けていたのだ。そのため、`main` 終了後の `atexit` で走る `OPENSSL_cleanup` と、まだ動いている curl の接続終了処理が、同じ OpenSSL のグローバル状態を並走して片付けに行く窓が構造として存在していたのだ。

## 変更内容なのだ

- `withEvaluator`（`Evaluator.kt`）: 撃ちっぱなしの `daemonScope.cancel()` を、完了まで待つ `cancelAndJoin()` に変更するのだ。
- `RuntimeContext`（`RuntimeContext.kt`）: `httpClient.close()` を `NonCancellable` で包み、close 後にクライアントの `Job` の完了まで待つようにするのだ。

なお、観測されたクラッシュは Xarpite が終了を握らないテストランナー側の経路で起きていたため、この緩和策だけで当該クラッシュが完全に消えると断定できるものではないのだ。あくまで並走の窓を狭める構造的な緩和なのだ。