### PR TITLE
`XarpiteGrammar` が `apiVersion` をコンストラクタ引数に取るようにするのだ〜

### DIFF
--- a/browser/src/jsMain/kotlin/mirrg/xarpite/js/browser/JsBrowserMain.kt
+++ b/browser/src/jsMain/kotlin/mirrg/xarpite/js/browser/JsBrowserMain.kt
@@ -55,10 +55,10 @@ fun evaluate(src: String, quiet: Boolean, out: (dynamic) -> Promise<Unit>): Prom
         evaluator.defineMounts(context.run { createCommonMounts() + createJsMounts() + createJsBrowserMounts() })
         try {
             if (quiet) {
-                evaluator.run("-", src, false)
+                evaluator.run("-", src, false, context.apiVersion)
                 undefined
             } else {
-                evaluator.get("-", src, false).cache()
+                evaluator.get("-", src, false, context.apiVersion).cache()
             }
         } catch (e: FluoriteException) {
             context.io.err("ERROR: ${e.message}".toFluoriteString())

--- a/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
@@ -33,8 +33,8 @@ class Evaluator {
         }
     }
 
-    suspend fun get(location: String, src: String, embedded: Boolean): FluoriteValue {
-        val parseResult = XarpiteGrammar(location, RuntimeContext.SUPPORTED_API_VERSIONS.first)
+    suspend fun get(location: String, src: String, embedded: Boolean, apiVersion: Int): FluoriteValue {
+        val parseResult = XarpiteGrammar(location, apiVersion)
             .let { if (embedded) it.rootEmbeddedParser else it.rootParser }
             .parseAll(src) { XarpiteParseContext(it) }
             .getOrThrow()
@@ -54,8 +54,8 @@ class Evaluator {
         }
     }
 
-    suspend fun run(location: String, src: String, embedded: Boolean) {
-        val parseResult = XarpiteGrammar(location, RuntimeContext.SUPPORTED_API_VERSIONS.first)
+    suspend fun run(location: String, src: String, embedded: Boolean, apiVersion: Int) {
+        val parseResult = XarpiteGrammar(location, apiVersion)
             .let { if (embedded) it.rootEmbeddedParser else it.rootParser }
             .parseAll(src) { XarpiteParseContext(it) }
             .getOrThrow()

--- a/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
@@ -34,7 +34,7 @@ class Evaluator {
     }
 
     suspend fun get(location: String, src: String, embedded: Boolean): FluoriteValue {
-        val parseResult = XarpiteGrammar(location)
+        val parseResult = XarpiteGrammar(location, RuntimeContext.SUPPORTED_API_VERSIONS.first)
             .let { if (embedded) it.rootEmbeddedParser else it.rootParser }
             .parseAll(src) { XarpiteParseContext(it) }
             .getOrThrow()
@@ -55,7 +55,7 @@ class Evaluator {
     }
 
     suspend fun run(location: String, src: String, embedded: Boolean) {
-        val parseResult = XarpiteGrammar(location)
+        val parseResult = XarpiteGrammar(location, RuntimeContext.SUPPORTED_API_VERSIONS.first)
             .let { if (embedded) it.rootEmbeddedParser else it.rootParser }
             .parseAll(src) { XarpiteParseContext(it) }
             .getOrThrow()

--- a/src/commonMain/kotlin/mirrg/xarpite/Grammar.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Grammar.kt
@@ -24,7 +24,7 @@ import io.github.mirrgieriana.xarpeg.text
 import mirrg.kotlin.helium.join
 
 @Suppress("MemberVisibilityCanBePrivate", "unused")
-class XarpiteGrammar(val location: String) {
+class XarpiteGrammar(val location: String, val apiVersion: Int) {
 
     val lineComment: Parser<Tuple0> = -Regex("""(?:#|//)[^\r\n]*""")
 

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
@@ -200,9 +200,9 @@ suspend fun CoroutineScope.cliEval(ioContext: IoContext, options: Options, creat
         evaluator.defineMounts(mountsFactory(location))
         try {
             if (options.quiet) {
-                evaluator.run(location, options.src, options.embedded)
+                evaluator.run(location, options.src, options.embedded, context.apiVersion)
             } else {
-                val result = evaluator.get(location, options.src, options.embedded)
+                val result = evaluator.get(location, options.src, options.embedded, context.apiVersion)
                 if (options.embedded) {
                     context.io.writeBytesToStdout(result.toFluoriteString(null).value.encodeToByteArray())
                 } else if (result is FluoriteStream) {

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/ModuleMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/ModuleMounts.kt
@@ -35,7 +35,7 @@ fun createModuleMounts(location: String, mountsFactory: (String) -> List<Map<Str
                 context.moduleResults.getOrPut(moduleLocation) {
                     val evaluator = Evaluator()
                     evaluator.defineMounts(mountsFactory(moduleLocation))
-                    evaluator.get(moduleLocation, src, false).cache()
+                    evaluator.get(moduleLocation, src, false, context.apiVersion).cache()
                 }
             }
         },
@@ -53,7 +53,7 @@ fun createModuleMounts(location: String, mountsFactory: (String) -> List<Map<Str
 
             val evaluator = Evaluator()
             evaluator.defineMounts(mountsFactory(scriptLocation))
-            evaluator.get(scriptLocation, script, false)
+            evaluator.get(scriptLocation, script, false, context.apiVersion)
         },
     ).let { listOf(it) }
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/test/TestUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/test/TestUtil.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.toList
 import mirrg.xarpite.Evaluator
 import mirrg.xarpite.Frame
 import mirrg.xarpite.IoContext
+import mirrg.xarpite.RuntimeContext
 import mirrg.xarpite.UnsupportedIoContext
 import mirrg.xarpite.XarpiteGrammar
 import mirrg.xarpite.XarpiteParseContext
@@ -26,7 +27,7 @@ import mirrg.xarpite.mounts.createCommonMounts
 import mirrg.xarpite.withEvaluator
 
 fun parse(src: String): String {
-    val parseResult = XarpiteGrammar("test").rootParser.parseAll(src) { XarpiteParseContext(it) }.getOrThrow()
+    val parseResult = XarpiteGrammar("test", RuntimeContext.SUPPORTED_API_VERSIONS.first).rootParser.parseAll(src) { XarpiteParseContext(it) }.getOrThrow()
     val frame = Frame()
     val getter = frame.compileToGetter(parseResult)
     return getter.code

--- a/src/commonMain/kotlin/mirrg/xarpite/test/TestUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/test/TestUtil.kt
@@ -47,11 +47,11 @@ suspend fun CoroutineScope.evalEmbedded(src: String, ioContext: IoContext = Unsu
     }
 }
 
-suspend fun Evaluator.get(src: String) = this.get("test", src, false)
+suspend fun Evaluator.get(src: String) = this.get("test", src, false, RuntimeContext.SUPPORTED_API_VERSIONS.first)
 
-suspend fun Evaluator.getEmbedded(src: String) = this.get("test", src, true)
+suspend fun Evaluator.getEmbedded(src: String) = this.get("test", src, true, RuntimeContext.SUPPORTED_API_VERSIONS.first)
 
-suspend fun Evaluator.run(src: String) = this.run("test", src, false)
+suspend fun Evaluator.run(src: String) = this.run("test", src, false, RuntimeContext.SUPPORTED_API_VERSIONS.first)
 
 val FluoriteValue.int get() = (this as FluoriteInt).value
 val FluoriteValue.big get() = (this as FluoriteBig).value


### PR DESCRIPTION
`XarpiteGrammar` が API バージョンを示す `apiVersion` をコンストラクタ引数に取るようにする、挙動を変えない純粋なリファクタリングなのだ。

これまで `XarpiteGrammar` はコンストラクタで `location` のみを受け取っていたのだが、ここに `apiVersion: Int` を追加するのだ。デフォルト値は持たせず、呼び出し元から明示的に値を渡すのだ。

文法側でこの値を使った分岐は本 PR では行わず、後続の API バージョン 5 の破壊的変更（PR #608）が乗るための土台を用意するに留めるのだ。

## 文脈

この変更は PR #608 のコメント https://github.com/MirrgieRiana/xarpite/pull/608#issuecomment-4766693781 における依頼に基づくのだ。