### PR TITLE
CODE_POINT を追加しちゃうのだっ！

### DIFF
--- a/changelog.d/add-code-point-functions.md
+++ b/changelog.d/add-code-point-functions.md
@@ -1,0 +1,1 @@
+Added `CODE_POINT`, `CODE_POINTD`, `CODE_POINTS`, and `CODE_POINTSD` functions for converting between strings and Unicode code point values.

--- a/changelog.d/add-code-point-functions.md
+++ b/changelog.d/add-code-point-functions.md
@@ -1,1 +1,1 @@
-Added `CODE_POINT`, `CODE_POINTD`, `CODE_POINTS`, and `CODE_POINTSD` functions for converting between strings and Unicode code point values.
+Added `CODE_POINT` and `CODE_POINTD` functions for converting between strings and Unicode code point values.

--- a/changelog.d/add-code-point-functions.md
+++ b/changelog.d/add-code-point-functions.md
@@ -1,1 +1,1 @@
-Added `CODE_POINT` and `CODE_POINTD` functions for converting between strings and Unicode code point values.
+Added `CODE_POINT` function that returns the Unicode code point value of a string consisting of exactly one code point.

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -538,23 +538,37 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CHAR_CODESD(charCodes: STREAM<INT>): STRING`
 
+`CODE_POINT(char: STRING): INT`
+
+`CODE_POINTD(codePoint: INT): STRING`
+
+`CODE_POINTS(string: STRING): STREAM<INT>`
+
+`CODE_POINTSD(codePoints: STREAM<INT>): STRING`
+
 These functions convert between strings and character codes.
 
-The `CHAR_CODE` family works in UTF-16 code units.
+The `CHAR_CODE` family works in UTF-16 code units, whereas the `CODE_POINT` family treats a character represented by a surrogate pair (U+10000 and above) as a single Unicode code point.
 
 Functions with the `D` suffix decode, while those without it encode.
 
-| Function      | Pre-decode type | Pre-decode meaning      | Direction   | Post-decode type | Post-decode meaning          |
-|---------------|-----------------|-------------------------|-------------|------------------|------------------------------|
-| `CHAR_CODE`   | `INT`           | code unit value         | ← to code   | `STRING`         | exactly one UTF-16 code unit |
-| `CHAR_CODED`  | `INT`           | code unit value         | → to string | `STRING`         | exactly one UTF-16 code unit |
-| `CHAR_CODES`  | `STREAM<INT>`   | value of each code unit | ← to code   | `STRING`         | string                       |
-| `CHAR_CODESD` | `STREAM<INT>`   | value of each code unit | → to string | `STRING`         | string                       |
+| Function       | Pre-decode type | Pre-decode meaning       | Direction   | Post-decode type | Post-decode meaning            |
+|----------------|-----------------|--------------------------|-------------|------------------|--------------------------------|
+| `CHAR_CODE`    | `INT`           | code unit value          | ← to code   | `STRING`         | exactly one UTF-16 code unit   |
+| `CHAR_CODED`   | `INT`           | code unit value          | → to string | `STRING`         | exactly one UTF-16 code unit   |
+| `CHAR_CODES`   | `STREAM<INT>`   | value of each code unit  | ← to code   | `STRING`         | string                         |
+| `CHAR_CODESD`  | `STREAM<INT>`   | value of each code unit  | → to string | `STRING`         | string                         |
+| `CODE_POINT`   | `INT`           | code point value         | ← to code   | `STRING`         | exactly one Unicode code point |
+| `CODE_POINTD`  | `INT`           | code point value         | → to string | `STRING`         | exactly one Unicode code point |
+| `CODE_POINTS`  | `STREAM<INT>`   | value of each code point | ← to code   | `STRING`         | string                         |
+| `CODE_POINTSD` | `STREAM<INT>`   | value of each code point | → to string | `STRING`         | string                         |
 
 An error is raised for inputs that fall under any of the following:
 
 - `CHAR_CODED` `CHAR_CODESD`: given a value that is not between 0 and 65535
-- `CHAR_CODE`: given a string that does not consist of exactly one code unit
+- `CODE_POINTD` `CODE_POINTSD`: given a value that is not between 0 and 1114111, or a surrogate code point (U+D800 to U+DFFF)
+- `CHAR_CODE` `CODE_POINT`: given a string that does not consist of exactly one code unit or code point, respectively
+- `CODE_POINT` `CODE_POINTS`: given a string that contains an isolated surrogate
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -577,6 +591,27 @@ $ xa 'CHAR_CODESD(65, 66, 67)'
 
 $ xa '"Hello" >> CHAR_CODES >> CHAR_CODESD'
 # Hello
+
+$ xa 'CODE_POINT("A")'
+# 65
+
+$ xa 'CODE_POINT("🍰")'
+# 127856
+
+$ xa 'CODE_POINTD(65)'
+# A
+
+$ xa 'CODE_POINTD(127856)'
+# 🍰
+
+$ xa 'CODE_POINTS("🍰") >> JOIN[","]'
+# 127856
+
+$ xa 'CODE_POINTSD(127856)'
+# 🍰
+
+$ xa '"🍰" >> CODE_POINTS >> CODE_POINTSD'
+# 🍰
 ```
 
 ## `UC` Convert to Uppercase

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -540,11 +540,9 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CODE_POINT(char: STRING): INT`
 
-`CODE_POINTD(codePoint: INT): STRING`
-
 These functions convert between strings and character codes.
 
-The `CHAR_CODE` family works in UTF-16 code units, whereas the `CODE_POINT` family treats a character represented by a surrogate pair (U+10000 and above) as a single Unicode code point.
+The `CHAR_CODE` family works in UTF-16 code units, whereas `CODE_POINT` treats a character represented by a surrogate pair (U+10000 and above) as a single Unicode code point.
 
 Functions with the `D` suffix decode, while those without it encode.
 
@@ -555,12 +553,10 @@ Functions with the `D` suffix decode, while those without it encode.
 | `CHAR_CODES`  | `STREAM<INT>`   | value of each code unit | ← to code   | `STRING`         | string                         |
 | `CHAR_CODESD` | `STREAM<INT>`   | value of each code unit | → to string | `STRING`         | string                         |
 | `CODE_POINT`  | `INT`           | code point value        | ← to code   | `STRING`         | exactly one Unicode code point |
-| `CODE_POINTD` | `INT`           | code point value        | → to string | `STRING`         | exactly one Unicode code point |
 
 An error is raised for inputs that fall under any of the following:
 
 - `CHAR_CODED` `CHAR_CODESD`: given a value that is not between 0 and 65535
-- `CODE_POINTD`: given a value that is not between 0 and 1114111, or a surrogate code point (U+D800 to U+DFFF)
 - `CHAR_CODE` `CODE_POINT`: given a string that does not consist of exactly one code unit or code point, respectively
 - `CODE_POINT`: given a string that contains an isolated surrogate
 
@@ -591,12 +587,6 @@ $ xa 'CODE_POINT("A")'
 
 $ xa 'CODE_POINT("🍰")'
 # 127856
-
-$ xa 'CODE_POINTD(65)'
-# A
-
-$ xa 'CODE_POINTD(127856)'
-# 🍰
 ```
 
 ## `UC` Convert to Uppercase

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -542,33 +542,27 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CODE_POINTD(codePoint: INT): STRING`
 
-`CODE_POINTS(string: STRING): STREAM<INT>`
-
-`CODE_POINTSD(codePoints: STREAM<INT>): STRING`
-
 These functions convert between strings and character codes.
 
 The `CHAR_CODE` family works in UTF-16 code units, whereas the `CODE_POINT` family treats a character represented by a surrogate pair (U+10000 and above) as a single Unicode code point.
 
 Functions with the `D` suffix decode, while those without it encode.
 
-| Function       | Pre-decode type | Pre-decode meaning       | Direction   | Post-decode type | Post-decode meaning            |
-|----------------|-----------------|--------------------------|-------------|------------------|--------------------------------|
-| `CHAR_CODE`    | `INT`           | code unit value          | ← to code   | `STRING`         | exactly one UTF-16 code unit   |
-| `CHAR_CODED`   | `INT`           | code unit value          | → to string | `STRING`         | exactly one UTF-16 code unit   |
-| `CHAR_CODES`   | `STREAM<INT>`   | value of each code unit  | ← to code   | `STRING`         | string                         |
-| `CHAR_CODESD`  | `STREAM<INT>`   | value of each code unit  | → to string | `STRING`         | string                         |
-| `CODE_POINT`   | `INT`           | code point value         | ← to code   | `STRING`         | exactly one Unicode code point |
-| `CODE_POINTD`  | `INT`           | code point value         | → to string | `STRING`         | exactly one Unicode code point |
-| `CODE_POINTS`  | `STREAM<INT>`   | value of each code point | ← to code   | `STRING`         | string                         |
-| `CODE_POINTSD` | `STREAM<INT>`   | value of each code point | → to string | `STRING`         | string                         |
+| Function      | Pre-decode type | Pre-decode meaning      | Direction   | Post-decode type | Post-decode meaning            |
+|---------------|-----------------|-------------------------|-------------|------------------|--------------------------------|
+| `CHAR_CODE`   | `INT`           | code unit value         | ← to code   | `STRING`         | exactly one UTF-16 code unit   |
+| `CHAR_CODED`  | `INT`           | code unit value         | → to string | `STRING`         | exactly one UTF-16 code unit   |
+| `CHAR_CODES`  | `STREAM<INT>`   | value of each code unit | ← to code   | `STRING`         | string                         |
+| `CHAR_CODESD` | `STREAM<INT>`   | value of each code unit | → to string | `STRING`         | string                         |
+| `CODE_POINT`  | `INT`           | code point value        | ← to code   | `STRING`         | exactly one Unicode code point |
+| `CODE_POINTD` | `INT`           | code point value        | → to string | `STRING`         | exactly one Unicode code point |
 
 An error is raised for inputs that fall under any of the following:
 
 - `CHAR_CODED` `CHAR_CODESD`: given a value that is not between 0 and 65535
-- `CODE_POINTD` `CODE_POINTSD`: given a value that is not between 0 and 1114111, or a surrogate code point (U+D800 to U+DFFF)
+- `CODE_POINTD`: given a value that is not between 0 and 1114111, or a surrogate code point (U+D800 to U+DFFF)
 - `CHAR_CODE` `CODE_POINT`: given a string that does not consist of exactly one code unit or code point, respectively
-- `CODE_POINT` `CODE_POINTS`: given a string that contains an isolated surrogate
+- `CODE_POINT`: given a string that contains an isolated surrogate
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -602,15 +596,6 @@ $ xa 'CODE_POINTD(65)'
 # A
 
 $ xa 'CODE_POINTD(127856)'
-# 🍰
-
-$ xa 'CODE_POINTS("🍰") >> JOIN[","]'
-# 127856
-
-$ xa 'CODE_POINTSD(127856)'
-# 🍰
-
-$ xa '"🍰" >> CODE_POINTS >> CODE_POINTSD'
 # 🍰
 ```
 

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -542,33 +542,27 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CODE_POINTD(codePoint: INT): STRING`
 
-`CODE_POINTS(string: STRING): STREAM<INT>`
-
-`CODE_POINTSD(codePoints: STREAM<INT>): STRING`
-
 文字列と文字コードを相互に変換します。
 
 `CHAR_CODE` 系はUTF-16コード単位を単位とし、`CODE_POINT` 系はサロゲートペアで表される文字（U+10000以上）を1個のUnicodeコードポイントとして扱います。
 
 末尾に `D` が付く関数はデコード、付かない関数はエンコードに対応します。
 
-| 関数           | デコード前の型 | デコード前の意味       | 変換方向   | デコード後の型 | デコード後の意味               |
-|----------------|----------------|------------------------|------------|----------------|--------------------------------|
-| `CHAR_CODE`    | `INT`          | コード単位の数値       | ← コード化 | `STRING`       | 丁度1個のUTF-16コード単位      |
-| `CHAR_CODED`   | `INT`          | コード単位の数値       | → 文字列化 | `STRING`       | 丁度1個のUTF-16コード単位      |
-| `CHAR_CODES`   | `STREAM<INT>`  | 各コード単位の数値     | ← コード化 | `STRING`       | 文字列                         |
-| `CHAR_CODESD`  | `STREAM<INT>`  | 各コード単位の数値     | → 文字列化 | `STRING`       | 文字列                         |
-| `CODE_POINT`   | `INT`          | コードポイントの数値   | ← コード化 | `STRING`       | 丁度1個のUnicodeコードポイント |
-| `CODE_POINTD`  | `INT`          | コードポイントの数値   | → 文字列化 | `STRING`       | 丁度1個のUnicodeコードポイント |
-| `CODE_POINTS`  | `STREAM<INT>`  | 各コードポイントの数値 | ← コード化 | `STRING`       | 文字列                         |
-| `CODE_POINTSD` | `STREAM<INT>`  | 各コードポイントの数値 | → 文字列化 | `STRING`       | 文字列                         |
+| 関数          | デコード前の型 | デコード前の意味     | 変換方向   | デコード後の型 | デコード後の意味               |
+|---------------|----------------|----------------------|------------|----------------|--------------------------------|
+| `CHAR_CODE`   | `INT`          | コード単位の数値     | ← コード化 | `STRING`       | 丁度1個のUTF-16コード単位      |
+| `CHAR_CODED`  | `INT`          | コード単位の数値     | → 文字列化 | `STRING`       | 丁度1個のUTF-16コード単位      |
+| `CHAR_CODES`  | `STREAM<INT>`  | 各コード単位の数値   | ← コード化 | `STRING`       | 文字列                         |
+| `CHAR_CODESD` | `STREAM<INT>`  | 各コード単位の数値   | → 文字列化 | `STRING`       | 文字列                         |
+| `CODE_POINT`  | `INT`          | コードポイントの数値 | ← コード化 | `STRING`       | 丁度1個のUnicodeコードポイント |
+| `CODE_POINTD` | `INT`          | コードポイントの数値 | → 文字列化 | `STRING`       | 丁度1個のUnicodeコードポイント |
 
 次のいずれかに該当する入力に対しては、エラーになります。
 
 - `CHAR_CODED` `CHAR_CODESD`: 0以上65535以下でない数値を与えた場合
-- `CODE_POINTD` `CODE_POINTSD`: 0以上1114111以下でない数値、またはサロゲートコードポイント（U+D800～U+DFFF）を与えた場合
+- `CODE_POINTD`: 0以上1114111以下でない数値、またはサロゲートコードポイント（U+D800～U+DFFF）を与えた場合
 - `CHAR_CODE` `CODE_POINT`: コード単位またはコードポイントが丁度1個でない文字列を与えた場合
-- `CODE_POINT` `CODE_POINTS`: 孤立サロゲートを含む文字列を与えた場合
+- `CODE_POINT`: 孤立サロゲートを含む文字列を与えた場合
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -602,15 +596,6 @@ $ xa 'CODE_POINTD(65)'
 # A
 
 $ xa 'CODE_POINTD(127856)'
-# 🍰
-
-$ xa 'CODE_POINTS("🍰") >> JOIN[","]'
-# 127856
-
-$ xa 'CODE_POINTSD(127856)'
-# 🍰
-
-$ xa '"🍰" >> CODE_POINTS >> CODE_POINTSD'
 # 🍰
 ```
 

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -538,23 +538,37 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CHAR_CODESD(charCodes: STREAM<INT>): STRING`
 
+`CODE_POINT(char: STRING): INT`
+
+`CODE_POINTD(codePoint: INT): STRING`
+
+`CODE_POINTS(string: STRING): STREAM<INT>`
+
+`CODE_POINTSD(codePoints: STREAM<INT>): STRING`
+
 文字列と文字コードを相互に変換します。
 
-`CHAR_CODE` 系はUTF-16コード単位を単位とします。
+`CHAR_CODE` 系はUTF-16コード単位を単位とし、`CODE_POINT` 系はサロゲートペアで表される文字（U+10000以上）を1個のUnicodeコードポイントとして扱います。
 
 末尾に `D` が付く関数はデコード、付かない関数はエンコードに対応します。
 
-| 関数          | デコード前の型 | デコード前の意味   | 変換方向   | デコード後の型 | デコード後の意味          |
-|---------------|----------------|--------------------|------------|----------------|---------------------------|
-| `CHAR_CODE`   | `INT`          | コード単位の数値   | ← コード化 | `STRING`       | 丁度1個のUTF-16コード単位 |
-| `CHAR_CODED`  | `INT`          | コード単位の数値   | → 文字列化 | `STRING`       | 丁度1個のUTF-16コード単位 |
-| `CHAR_CODES`  | `STREAM<INT>`  | 各コード単位の数値 | ← コード化 | `STRING`       | 文字列                    |
-| `CHAR_CODESD` | `STREAM<INT>`  | 各コード単位の数値 | → 文字列化 | `STRING`       | 文字列                    |
+| 関数           | デコード前の型 | デコード前の意味       | 変換方向   | デコード後の型 | デコード後の意味               |
+|----------------|----------------|------------------------|------------|----------------|--------------------------------|
+| `CHAR_CODE`    | `INT`          | コード単位の数値       | ← コード化 | `STRING`       | 丁度1個のUTF-16コード単位      |
+| `CHAR_CODED`   | `INT`          | コード単位の数値       | → 文字列化 | `STRING`       | 丁度1個のUTF-16コード単位      |
+| `CHAR_CODES`   | `STREAM<INT>`  | 各コード単位の数値     | ← コード化 | `STRING`       | 文字列                         |
+| `CHAR_CODESD`  | `STREAM<INT>`  | 各コード単位の数値     | → 文字列化 | `STRING`       | 文字列                         |
+| `CODE_POINT`   | `INT`          | コードポイントの数値   | ← コード化 | `STRING`       | 丁度1個のUnicodeコードポイント |
+| `CODE_POINTD`  | `INT`          | コードポイントの数値   | → 文字列化 | `STRING`       | 丁度1個のUnicodeコードポイント |
+| `CODE_POINTS`  | `STREAM<INT>`  | 各コードポイントの数値 | ← コード化 | `STRING`       | 文字列                         |
+| `CODE_POINTSD` | `STREAM<INT>`  | 各コードポイントの数値 | → 文字列化 | `STRING`       | 文字列                         |
 
 次のいずれかに該当する入力に対しては、エラーになります。
 
 - `CHAR_CODED` `CHAR_CODESD`: 0以上65535以下でない数値を与えた場合
-- `CHAR_CODE`: コード単位が丁度1個でない文字列を与えた場合
+- `CODE_POINTD` `CODE_POINTSD`: 0以上1114111以下でない数値、またはサロゲートコードポイント（U+D800～U+DFFF）を与えた場合
+- `CHAR_CODE` `CODE_POINT`: コード単位またはコードポイントが丁度1個でない文字列を与えた場合
+- `CODE_POINT` `CODE_POINTS`: 孤立サロゲートを含む文字列を与えた場合
 
 ```shell
 $ xa 'CHAR_CODE("A")'
@@ -577,6 +591,27 @@ $ xa 'CHAR_CODESD(65, 66, 67)'
 
 $ xa '"Hello" >> CHAR_CODES >> CHAR_CODESD'
 # Hello
+
+$ xa 'CODE_POINT("A")'
+# 65
+
+$ xa 'CODE_POINT("🍰")'
+# 127856
+
+$ xa 'CODE_POINTD(65)'
+# A
+
+$ xa 'CODE_POINTD(127856)'
+# 🍰
+
+$ xa 'CODE_POINTS("🍰") >> JOIN[","]'
+# 127856
+
+$ xa 'CODE_POINTSD(127856)'
+# 🍰
+
+$ xa '"🍰" >> CODE_POINTS >> CODE_POINTSD'
+# 🍰
 ```
 
 ## `UC` 大文字に変換

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -540,11 +540,9 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CODE_POINT(char: STRING): INT`
 
-`CODE_POINTD(codePoint: INT): STRING`
-
 文字列と文字コードを相互に変換します。
 
-`CHAR_CODE` 系はUTF-16コード単位を単位とし、`CODE_POINT` 系はサロゲートペアで表される文字（U+10000以上）を1個のUnicodeコードポイントとして扱います。
+`CHAR_CODE` 系はUTF-16コード単位を単位とし、`CODE_POINT` はサロゲートペアで表される文字（U+10000以上）を1個のUnicodeコードポイントとして扱います。
 
 末尾に `D` が付く関数はデコード、付かない関数はエンコードに対応します。
 
@@ -555,12 +553,10 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 | `CHAR_CODES`  | `STREAM<INT>`  | 各コード単位の数値   | ← コード化 | `STRING`       | 文字列                         |
 | `CHAR_CODESD` | `STREAM<INT>`  | 各コード単位の数値   | → 文字列化 | `STRING`       | 文字列                         |
 | `CODE_POINT`  | `INT`          | コードポイントの数値 | ← コード化 | `STRING`       | 丁度1個のUnicodeコードポイント |
-| `CODE_POINTD` | `INT`          | コードポイントの数値 | → 文字列化 | `STRING`       | 丁度1個のUnicodeコードポイント |
 
 次のいずれかに該当する入力に対しては、エラーになります。
 
 - `CHAR_CODED` `CHAR_CODESD`: 0以上65535以下でない数値を与えた場合
-- `CODE_POINTD`: 0以上1114111以下でない数値、またはサロゲートコードポイント（U+D800～U+DFFF）を与えた場合
 - `CHAR_CODE` `CODE_POINT`: コード単位またはコードポイントが丁度1個でない文字列を与えた場合
 - `CODE_POINT`: 孤立サロゲートを含む文字列を与えた場合
 
@@ -591,12 +587,6 @@ $ xa 'CODE_POINT("A")'
 
 $ xa 'CODE_POINT("🍰")'
 # 127856
-
-$ xa 'CODE_POINTD(65)'
-# A
-
-$ xa 'CODE_POINTD(127856)'
-# 🍰
 ```
 
 ## `UC` 大文字に変換

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -103,55 +103,6 @@ fun createStringMounts(): List<Map<String, Mount>> {
             }
             string.toFluoriteString()
         },
-        "CODE_POINTS" define FluoriteFunction.immediate { arguments ->
-            if (arguments.size != 1) usage("CODE_POINTS(string: STRING): STREAM<INT>")
-            val string = arguments[0].toFluoriteString(null).value
-            FluoriteStream {
-                var i = 0
-                while (i < string.length) {
-                    val char = string[i]
-                    if (char.isHighSurrogate()) {
-                        if (i + 1 < string.length && string[i + 1].isLowSurrogate()) {
-                            val codePoint = 0x10000 + ((char.code - 0xD800) shl 10) + (string[i + 1].code - 0xDC00)
-                            emit(FluoriteInt(codePoint))
-                            i += 2
-                        } else {
-                            throw FluoriteException("String must not contain an isolated surrogate".toFluoriteString())
-                        }
-                    } else if (char.isLowSurrogate()) {
-                        throw FluoriteException("String must not contain an isolated surrogate".toFluoriteString())
-                    } else {
-                        emit(FluoriteInt(char.code))
-                        i++
-                    }
-                }
-            }
-        },
-        "CODE_POINTSD" define FluoriteFunction.immediate { arguments ->
-            if (arguments.size != 1) usage("CODE_POINTSD(codePoints: STREAM<INT>): STRING")
-            val value = arguments[0]
-            val sb = StringBuilder()
-            suspend fun appendCodePoint(item: FluoriteValue) {
-                val codePoint = item.toFluoriteNumber(null).roundToInt()
-                if (codePoint < 0 || codePoint > 0x10FFFF) throw FluoriteException("Each element must be between 0 and 1114111, got $codePoint".toFluoriteString())
-                if (codePoint in 0xD800..0xDFFF) throw FluoriteException("Surrogate code points are not allowed, got $codePoint".toFluoriteString())
-                if (codePoint < 0x10000) {
-                    sb.append(codePoint.toChar())
-                } else {
-                    val offset = codePoint - 0x10000
-                    sb.append((0xD800 + (offset shr 10)).toChar())
-                    sb.append((0xDC00 + (offset and 0x3FF)).toChar())
-                }
-            }
-            if (value is FluoriteStream) {
-                value.collect { item ->
-                    appendCodePoint(item)
-                }
-            } else {
-                appendCodePoint(value)
-            }
-            sb.toString().toFluoriteString()
-        },
 
         *run {
             fun create(signature: String): FluoriteFunction {

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -88,21 +88,6 @@ fun createStringMounts(): List<Map<String, Mount>> {
             }
             FluoriteInt(codePoint)
         },
-        "CODE_POINTD" define FluoriteFunction.immediate { arguments ->
-            if (arguments.size != 1) usage("CODE_POINTD(codePoint: INT): STRING")
-            val codePoint = arguments[0].toFluoriteNumber(null).roundToInt()
-            if (codePoint < 0 || codePoint > 0x10FFFF) throw FluoriteException("Argument must be between 0 and 1114111, got $codePoint".toFluoriteString())
-            if (codePoint in 0xD800..0xDFFF) throw FluoriteException("Surrogate code points are not allowed, got $codePoint".toFluoriteString())
-            val string = if (codePoint < 0x10000) {
-                codePoint.toChar().toString()
-            } else {
-                val offset = codePoint - 0x10000
-                val high = 0xD800 + (offset shr 10)
-                val low = 0xDC00 + (offset and 0x3FF)
-                "${high.toChar()}${low.toChar()}"
-            }
-            string.toFluoriteString()
-        },
 
         *run {
             fun create(signature: String): FluoriteFunction {

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -68,6 +68,91 @@ fun createStringMounts(): List<Map<String, Mount>> {
             sb.toString().toFluoriteString()
         },
 
+        "CODE_POINT" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("CODE_POINT(char: STRING): INT")
+            val string = arguments[0].toFluoriteString(null).value
+            val codePoint = when {
+                string.isEmpty() -> throw FluoriteException("Argument must be a string of exactly 1 Unicode code point, got an empty string".toFluoriteString())
+                string.length == 1 -> {
+                    val char = string[0]
+                    if (char.isSurrogate()) throw FluoriteException("Argument must not contain an isolated surrogate".toFluoriteString())
+                    char.code
+                }
+                string.length == 2 -> {
+                    val high = string[0]
+                    val low = string[1]
+                    if (!high.isHighSurrogate() || !low.isLowSurrogate()) throw FluoriteException("Argument must be a string of exactly 1 Unicode code point, got ${string.length} code units".toFluoriteString())
+                    0x10000 + ((high.code - 0xD800) shl 10) + (low.code - 0xDC00)
+                }
+                else -> throw FluoriteException("Argument must be a string of exactly 1 Unicode code point, got ${string.length} code units".toFluoriteString())
+            }
+            FluoriteInt(codePoint)
+        },
+        "CODE_POINTD" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("CODE_POINTD(codePoint: INT): STRING")
+            val codePoint = arguments[0].toFluoriteNumber(null).roundToInt()
+            if (codePoint < 0 || codePoint > 0x10FFFF) throw FluoriteException("Argument must be between 0 and 1114111, got $codePoint".toFluoriteString())
+            if (codePoint in 0xD800..0xDFFF) throw FluoriteException("Surrogate code points are not allowed, got $codePoint".toFluoriteString())
+            val string = if (codePoint < 0x10000) {
+                codePoint.toChar().toString()
+            } else {
+                val offset = codePoint - 0x10000
+                val high = 0xD800 + (offset shr 10)
+                val low = 0xDC00 + (offset and 0x3FF)
+                "${high.toChar()}${low.toChar()}"
+            }
+            string.toFluoriteString()
+        },
+        "CODE_POINTS" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("CODE_POINTS(string: STRING): STREAM<INT>")
+            val string = arguments[0].toFluoriteString(null).value
+            FluoriteStream {
+                var i = 0
+                while (i < string.length) {
+                    val char = string[i]
+                    if (char.isHighSurrogate()) {
+                        if (i + 1 < string.length && string[i + 1].isLowSurrogate()) {
+                            val codePoint = 0x10000 + ((char.code - 0xD800) shl 10) + (string[i + 1].code - 0xDC00)
+                            emit(FluoriteInt(codePoint))
+                            i += 2
+                        } else {
+                            throw FluoriteException("String must not contain an isolated surrogate".toFluoriteString())
+                        }
+                    } else if (char.isLowSurrogate()) {
+                        throw FluoriteException("String must not contain an isolated surrogate".toFluoriteString())
+                    } else {
+                        emit(FluoriteInt(char.code))
+                        i++
+                    }
+                }
+            }
+        },
+        "CODE_POINTSD" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("CODE_POINTSD(codePoints: STREAM<INT>): STRING")
+            val value = arguments[0]
+            val sb = StringBuilder()
+            suspend fun appendCodePoint(item: FluoriteValue) {
+                val codePoint = item.toFluoriteNumber(null).roundToInt()
+                if (codePoint < 0 || codePoint > 0x10FFFF) throw FluoriteException("Each element must be between 0 and 1114111, got $codePoint".toFluoriteString())
+                if (codePoint in 0xD800..0xDFFF) throw FluoriteException("Surrogate code points are not allowed, got $codePoint".toFluoriteString())
+                if (codePoint < 0x10000) {
+                    sb.append(codePoint.toChar())
+                } else {
+                    val offset = codePoint - 0x10000
+                    sb.append((0xD800 + (offset shr 10)).toChar())
+                    sb.append((0xDC00 + (offset and 0x3FF)).toChar())
+                }
+            }
+            if (value is FluoriteStream) {
+                value.collect { item ->
+                    appendCodePoint(item)
+                }
+            } else {
+                appendCodePoint(value)
+            }
+            sb.toString().toFluoriteString()
+        },
+
         *run {
             fun create(signature: String): FluoriteFunction {
                 return FluoriteFunction.immediate { arguments ->

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -81,7 +81,10 @@ fun createStringMounts(): List<Map<String, Mount>> {
                 string.length == 2 -> {
                     val high = string[0]
                     val low = string[1]
-                    if (!high.isHighSurrogate() || !low.isLowSurrogate()) throw FluoriteException("Argument must be a string of exactly 1 Unicode code point, got ${string.length} code units".toFluoriteString())
+                    if (!high.isHighSurrogate() || !low.isLowSurrogate()) {
+                        if (high.isSurrogate() || low.isSurrogate()) throw FluoriteException("Argument must not contain an isolated surrogate".toFluoriteString())
+                        throw FluoriteException("Argument must be a string of exactly 1 Unicode code point, got ${string.length} code units".toFluoriteString())
+                    }
                     0x10000 + ((high.code - 0xD800) shl 10) + (low.code - 0xDC00)
                 }
                 else -> throw FluoriteException("Argument must be a string of exactly 1 Unicode code point, got ${string.length} code units".toFluoriteString())

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -192,15 +192,5 @@ class StringMountsTest {
         assertFailsWith<FluoriteException> { eval("CODE_POINT('\uDC00')") } // 孤立下位サロゲートはエラー
         // 長さ2でも正しいサロゲートペアでない並びはエラー
         assertFailsWith<FluoriteException> { eval("CODE_POINT('\uD800A')") } // 上位サロゲートの後ろが下位サロゲートでないとエラー
-
-        // CODE_POINTD: コードポイントから文字列を返す
-        assertEquals("A", eval("CODE_POINTD(65)").string) // 65 は 'A'
-        assertEquals("\u3042", eval("CODE_POINTD(12354)").string) // 12354 は 'あ'
-        assertEquals("\uD83C\uDF70", eval("CODE_POINTD(127856)").string) // 127856 は 🍰
-
-        // CODE_POINTD: 範囲外の場合はエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTD(-1)") } // 負数はエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTD(1114112)") } // U+110000はエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTD(55296)") } // サロゲートはエラー（U+D800）
     }
 }

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -202,32 +202,5 @@ class StringMountsTest {
         assertFailsWith<FluoriteException> { eval("CODE_POINTD(-1)") } // 負数はエラー
         assertFailsWith<FluoriteException> { eval("CODE_POINTD(1114112)") } // U+110000はエラー
         assertFailsWith<FluoriteException> { eval("CODE_POINTD(55296)") } // サロゲートはエラー（U+D800）
-
-        // CODE_POINTS: 文字列からUnicodeコードポイントのストリームを返す
-        assertEquals("65,66,67", eval("CODE_POINTS('ABC')").stream()) // 'ABC'のコードポイント列
-        assertEquals("12354,12356", eval("CODE_POINTS('\u3042\u3044')").stream()) // 'あい'のコードポイント列
-        assertEquals("127856", eval("CODE_POINTS('\uD83C\uDF70')").stream()) // 🍰 のコードポイント
-        assertEquals("", eval("CODE_POINTS('')").stream()) // 空文字列は空ストリーム
-        // 孤立サロゲートはエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTS('\uD800')").stream() } // 孤立上位サロゲートはエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTS('\uDC00')").stream() } // 孤立下位サロゲートはエラー
-        // 上位サロゲートの直後が下位サロゲートでない並びはエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTS('\uD83CA')").stream() } // 上位サロゲート＋非下位サロゲートはエラー
-
-        // CODE_POINTSD: コードポイントのストリームから文字列を返す
-        assertEquals("ABC", eval("CODE_POINTSD(65, 66, 67)").string) // コードポイント列から文字列
-        assertEquals("\u3042\u3044", eval("CODE_POINTSD(12354, 12356)").string) // 日本語文字
-        assertEquals("\uD83C\uDF70", eval("CODE_POINTSD(127856)").string) // 🍰
-        assertEquals("A", eval("CODE_POINTSD(65)").string) // 単一のコードポイント
-
-        // CODE_POINTSD: 範囲外の場合はエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTSD(-1)") } // 負数はエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTSD(1114112)") } // U+110000はエラー
-        assertFailsWith<FluoriteException> { eval("CODE_POINTSD(55296)") } // サロゲートはエラー
-
-        // CODE_POINTSとCODE_POINTSDは逆変換
-        assertEquals("Hello", eval("'Hello' >> CODE_POINTS >> CODE_POINTSD").string)
-        // サロゲートペアも往復できる
-        assertEquals("\uD83C\uDF70", eval("'\uD83C\uDF70' >> CODE_POINTS >> CODE_POINTSD").string)
     }
 }

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -175,4 +175,59 @@ class StringMountsTest {
         // サロゲートペアも往復できる
         assertEquals("\uD83C\uDF70", eval("'\uD83C\uDF70' >> CHAR_CODES >> CHAR_CODESD").string)
     }
+
+    @Test
+    fun codePoint() = runTest {
+        // CODE_POINT: Unicodeコードポイントを返す
+        assertEquals(65, eval("CODE_POINT('A')").int) // 'A' のコードポイントは65
+        assertEquals(12354, eval("CODE_POINT('\u3042')").int) // 'あ' のコードポイントは12354
+        // サロゲートペアの文字（U+1F370 🍰 = 0x1F370 = 127856）
+        assertEquals(127856, eval("CODE_POINT('\uD83C\uDF70')").int) // 🍰 のコードポイント
+
+        // CODE_POINT: 1コードポイントでない場合はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINT('')") } // 空文字列はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINT('AB')") } // 2文字はエラー
+        // 孤立サロゲートはエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINT('\uD800')") } // 孤立上位サロゲートはエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINT('\uDC00')") } // 孤立下位サロゲートはエラー
+        // 長さ2でも正しいサロゲートペアでない並びはエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINT('\uD800A')") } // 上位サロゲートの後ろが下位サロゲートでないとエラー
+
+        // CODE_POINTD: コードポイントから文字列を返す
+        assertEquals("A", eval("CODE_POINTD(65)").string) // 65 は 'A'
+        assertEquals("\u3042", eval("CODE_POINTD(12354)").string) // 12354 は 'あ'
+        assertEquals("\uD83C\uDF70", eval("CODE_POINTD(127856)").string) // 127856 は 🍰
+
+        // CODE_POINTD: 範囲外の場合はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTD(-1)") } // 負数はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTD(1114112)") } // U+110000はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTD(55296)") } // サロゲートはエラー（U+D800）
+
+        // CODE_POINTS: 文字列からUnicodeコードポイントのストリームを返す
+        assertEquals("65,66,67", eval("CODE_POINTS('ABC')").stream()) // 'ABC'のコードポイント列
+        assertEquals("12354,12356", eval("CODE_POINTS('\u3042\u3044')").stream()) // 'あい'のコードポイント列
+        assertEquals("127856", eval("CODE_POINTS('\uD83C\uDF70')").stream()) // 🍰 のコードポイント
+        assertEquals("", eval("CODE_POINTS('')").stream()) // 空文字列は空ストリーム
+        // 孤立サロゲートはエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTS('\uD800')").stream() } // 孤立上位サロゲートはエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTS('\uDC00')").stream() } // 孤立下位サロゲートはエラー
+        // 上位サロゲートの直後が下位サロゲートでない並びはエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTS('\uD83CA')").stream() } // 上位サロゲート＋非下位サロゲートはエラー
+
+        // CODE_POINTSD: コードポイントのストリームから文字列を返す
+        assertEquals("ABC", eval("CODE_POINTSD(65, 66, 67)").string) // コードポイント列から文字列
+        assertEquals("\u3042\u3044", eval("CODE_POINTSD(12354, 12356)").string) // 日本語文字
+        assertEquals("\uD83C\uDF70", eval("CODE_POINTSD(127856)").string) // 🍰
+        assertEquals("A", eval("CODE_POINTSD(65)").string) // 単一のコードポイント
+
+        // CODE_POINTSD: 範囲外の場合はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTSD(-1)") } // 負数はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTSD(1114112)") } // U+110000はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTSD(55296)") } // サロゲートはエラー
+
+        // CODE_POINTSとCODE_POINTSDは逆変換
+        assertEquals("Hello", eval("'Hello' >> CODE_POINTS >> CODE_POINTSD").string)
+        // サロゲートペアも往復できる
+        assertEquals("\uD83C\uDF70", eval("'\uD83C\uDF70' >> CODE_POINTS >> CODE_POINTSD").string)
+    }
 }


### PR DESCRIPTION
Claude Fairyは https://github.com/MirrgieRiana/private/issues/16 に記載の Protocol 103F 必読なのだ

## 実装内容なのだ

文字列から、そのUnicodeコードポイントの数値を返す、以下の組み込み関数を追加するのだ〜♪

- `CODE_POINT(char: STRING): INT` — Unicodeコードポイントが丁度1個の文字列から、コードポイントの数値を返すのだ（サロゲートペアにも対応してて、孤立サロゲートはエラーになるのだ）

## 背景なのだ

[PR MirrgieRiana/xarpite#540](https://github.com/MirrgieRiana/xarpite/pull/540) は `CHAR_CODE` 系・`CODE_POINT` 系の合計8関数を一括で追加するものだったのだけど、レビューの負荷が大きくなりすぎたのだ。そこで、機能を小さく分割して、最新の `main` を起点に切り出すことにしたのだ〜。

このPRは、その分割の一環として、`CODE_POINT` 1関数だけを切り出したものなのだ。残りの `CODE_POINTD` / `CODE_POINTS` / `CODE_POINTSD` は、後続の独立PRへ分離するのだ〜。

ドキュメントは、`main` で既に整えられている `CHAR_CODE` 系の表形式のセクションへ、`CODE_POINT` を統合する形で記載しているのだ。

## 変更ファイルなのだ

- `src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt` — 実装なのだ
- `src/commonTest/kotlin/StringMountsTest.kt` — テストなのだ
- `pages/docs/ja/string.md` — 日本語ドキュメントなのだ
- `pages/docs/en/string.md` — 英語ドキュメントなのだ
- `changelog.d/add-code-point-functions.md` — 更新履歴の断片なのだ