### PR TITLE
`Environment` から `RuntimeContext` を参照できるようにするのだ

### DIFF
--- a/browser/src/jsMain/kotlin/mirrg/xarpite/js/browser/JsBrowserMain.kt
+++ b/browser/src/jsMain/kotlin/mirrg/xarpite/js/browser/JsBrowserMain.kt
@@ -55,10 +55,10 @@ fun evaluate(src: String, quiet: Boolean, out: (dynamic) -> Promise<Unit>): Prom
         evaluator.defineMounts(context.run { createCommonMounts() + createJsMounts() + createJsBrowserMounts() })
         try {
             if (quiet) {
-                evaluator.run("-", src, false, context.apiVersion)
+                evaluator.run("-", src, false)
                 undefined
             } else {
-                evaluator.get("-", src, false, context.apiVersion).cache()
+                evaluator.get("-", src, false).cache()
             }
         } catch (e: FluoriteException) {
             context.io.err("ERROR: ${e.message}".toFluoriteString())

--- a/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt
@@ -15,7 +15,7 @@ import mirrg.xarpite.compilers.objects.FluoriteValue
 import mirrg.xarpite.operations.FluoriteException
 import mirrg.xarpite.operations.Returner
 
-class Evaluator {
+class Evaluator(private val context: RuntimeContext) {
 
     private var currentFrame: Frame? = null
     private var currentEnv: Environment? = null
@@ -26,22 +26,22 @@ class Evaluator {
         val runners = maps.map {
             frame.defineBuiltinMount(it)
         }
-        val env = Environment(currentEnv, frame.nextVariableIndex, frame.mountCount)
+        val env = Environment(context, currentEnv, frame.nextVariableIndex, frame.mountCount)
         currentEnv = env
         runners.forEach {
             it.evaluate(env)
         }
     }
 
-    suspend fun get(location: String, src: String, embedded: Boolean, apiVersion: Int): FluoriteValue {
-        val parseResult = XarpiteGrammar(location, apiVersion)
+    suspend fun get(location: String, src: String, embedded: Boolean): FluoriteValue {
+        val parseResult = XarpiteGrammar(location, context.apiVersion)
             .let { if (embedded) it.rootEmbeddedParser else it.rootParser }
             .parseAll(src) { XarpiteParseContext(it) }
             .getOrThrow()
         val frame = Frame(currentFrame)
         currentFrame = frame
         val getter = frame.compileToGetter(parseResult)
-        val env = Environment(currentEnv, frame.nextVariableIndex, frame.mountCount)
+        val env = Environment(context, currentEnv, frame.nextVariableIndex, frame.mountCount)
         currentEnv = env
         return withStackTrace(Position(location, 0)) {
             try {
@@ -54,15 +54,15 @@ class Evaluator {
         }
     }
 
-    suspend fun run(location: String, src: String, embedded: Boolean, apiVersion: Int) {
-        val parseResult = XarpiteGrammar(location, apiVersion)
+    suspend fun run(location: String, src: String, embedded: Boolean) {
+        val parseResult = XarpiteGrammar(location, context.apiVersion)
             .let { if (embedded) it.rootEmbeddedParser else it.rootParser }
             .parseAll(src) { XarpiteParseContext(it) }
             .getOrThrow()
         val frame = Frame(currentFrame)
         currentFrame = frame
         val runners = frame.compileToRunner(parseResult)
-        val env = Environment(currentEnv, frame.nextVariableIndex, frame.mountCount)
+        val env = Environment(context, currentEnv, frame.nextVariableIndex, frame.mountCount)
         currentEnv = env
         withStackTrace(Position(location, 0)) {
             try {
@@ -84,7 +84,8 @@ suspend fun <T> CoroutineScope.withEvaluator(ioContext: IoContext, block: suspen
     try {
         return coroutineScope main@{
             withContext(StackTrace()) {
-                block(RuntimeContext(this, daemonScope, ioContext), Evaluator())
+                val context = RuntimeContext(this, daemonScope, ioContext)
+                block(context, Evaluator(context))
             }
         }
     } finally {

--- a/src/commonMain/kotlin/mirrg/xarpite/Frame.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Frame.kt
@@ -15,7 +15,7 @@ class Frame(val parent: Frame? = null) {
     var mountCount = 0
 }
 
-class Environment(val parent: Environment?, variableCount: Int, mountCount: Int) {
+class Environment(val context: RuntimeContext, val parent: Environment?, variableCount: Int, mountCount: Int) {
     val variableTable: Array<Array<Variable?>> = if (parent != null) {
         arrayOf(*parent.variableTable, arrayOfNulls(variableCount))
     } else {

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
@@ -200,9 +200,9 @@ suspend fun CoroutineScope.cliEval(ioContext: IoContext, options: Options, creat
         evaluator.defineMounts(mountsFactory(location))
         try {
             if (options.quiet) {
-                evaluator.run(location, options.src, options.embedded, context.apiVersion)
+                evaluator.run(location, options.src, options.embedded)
             } else {
-                val result = evaluator.get(location, options.src, options.embedded, context.apiVersion)
+                val result = evaluator.get(location, options.src, options.embedded)
                 if (options.embedded) {
                     context.io.writeBytesToStdout(result.toFluoriteString(null).value.encodeToByteArray())
                 } else if (result is FluoriteStream) {

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/ModuleMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/ModuleMounts.kt
@@ -33,9 +33,9 @@ fun createModuleMounts(location: String, mountsFactory: (String) -> List<Map<Str
                 val reference = arguments[0].toFluoriteString(null).value
                 val (moduleLocation, src) = resolveModuleLocation(context.inc, location, reference)
                 context.moduleResults.getOrPut(moduleLocation) {
-                    val evaluator = Evaluator()
+                    val evaluator = Evaluator(context)
                     evaluator.defineMounts(mountsFactory(moduleLocation))
-                    evaluator.get(moduleLocation, src, false, context.apiVersion).cache()
+                    evaluator.get(moduleLocation, src, false).cache()
                 }
             }
         },
@@ -51,9 +51,9 @@ fun createModuleMounts(location: String, mountsFactory: (String) -> List<Map<Str
             val reference = referenceArgument?.toFluoriteString(null)?.value ?: "./-"
             val scriptLocation = resolveScriptLocation(location, reference)
 
-            val evaluator = Evaluator()
+            val evaluator = Evaluator(context)
             evaluator.defineMounts(mountsFactory(scriptLocation))
-            evaluator.get(scriptLocation, script, false, context.apiVersion)
+            evaluator.get(scriptLocation, script, false)
         },
     ).let { listOf(it) }
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/operations/Getters.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/operations/Getters.kt
@@ -87,7 +87,7 @@ class StringConcatenationGetter(private val stringGetters: List<StringGetter>) :
 }
 
 class NewEnvironmentGetter(private val variableCount: Int, private val mountCount: Int, private val getter: Getter) : Getter {
-    override suspend fun evaluate(env: Environment) = getter.evaluate(Environment(env, variableCount, mountCount))
+    override suspend fun evaluate(env: Environment) = getter.evaluate(Environment(env.context, env, variableCount, mountCount))
     override val code get() = "NewEnvironmentGetter[$variableCount;$mountCount;${getter.code}]"
 }
 
@@ -129,7 +129,7 @@ class ObjectFromStreamGetter(private val getter: Getter) : Getter {
 class ObjectCreationGetter(private val parentGetter: Getter?, private val variableCount: Int, private val objectInitializers: List<ObjectInitializer>) : Getter {
     override suspend fun evaluate(env: Environment): FluoriteValue {
         val parent = parentGetter?.let { it.evaluate(env) as FluoriteObject } ?: FluoriteObject.fluoriteClass
-        val newEnv = Environment(env, variableCount, 0)
+        val newEnv = Environment(env.context, env, variableCount, 0)
         val map = mutableMapOf<String, FluoriteValue>()
         objectInitializers.forEach {
             it.initializeVariable(newEnv, map)
@@ -698,7 +698,7 @@ class EntryGetter(private val leftGetter: Getter, private val rightGetter: Gette
 class FunctionGetter(private val newFrameIndex: Int, private val argumentsVariableIndex: Int, private val variableIndices: List<Int>, private val isLazy: List<Boolean>, private val getter: Getter) : Getter {
     override suspend fun evaluate(env: Environment): FluoriteValue {
         return FluoriteFunction.create { arguments ->
-            val newEnv = Environment(env, 1 + variableIndices.size, 0)
+            val newEnv = Environment(env.context, env, 1 + variableIndices.size, 0)
             val evaluatedArguments = arguments.mapIndexed { i, argument ->
                 if (isLazy.getOrNull(i) ?: false) {
                     FluoriteFunction.immediate { argument() }
@@ -875,7 +875,7 @@ class TryCatchWithVariableGetter(private val leftGetter: Getter, private val new
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            val newEnv = Environment(env, 1, 0)
+            val newEnv = Environment(env.context, env, 1, 0)
             newEnv.variableTable[newFrameIndex][argumentVariableIndex] = LocalVariable(e.toFluoriteValue())
             rightGetter.evaluate(newEnv)
         }
@@ -903,7 +903,7 @@ class TryCatchGetter(private val leftGetter: Getter, private val rightGetter: Ge
 class LabelGetter(private val frameIndex: Int, private val variableIndex: Int, private val name: String, private val getter: Getter) : Getter {
     override suspend fun evaluate(env: Environment): FluoriteValue {
         val label = Label(name)
-        val newEnv = Environment(env, 1, 0)
+        val newEnv = Environment(env.context, env, 1, 0)
         newEnv.variableTable[frameIndex][variableIndex] = label
         try {
             return getter.evaluate(newEnv).cache()
@@ -928,7 +928,7 @@ class PipeGetter(private val streamGetter: Getter, private val newFrameIndex: In
             FluoriteStream {
                 var index = 0
                 stream.collect { value ->
-                    val newEnv = Environment(env, (indexVariableIndex?.let { 1 } ?: 0) + 1, 0)
+                    val newEnv = Environment(env.context, env, (indexVariableIndex?.let { 1 } ?: 0) + 1, 0)
                     if (indexVariableIndex != null) {
                         newEnv.variableTable[newFrameIndex][indexVariableIndex] = LocalVariable(FluoriteInt(index))
                     }
@@ -943,7 +943,7 @@ class PipeGetter(private val streamGetter: Getter, private val newFrameIndex: In
                 }
             }
         } else {
-            val newEnv = Environment(env, (indexVariableIndex?.let { 1 } ?: 0) + 1, 0)
+            val newEnv = Environment(env.context, env, (indexVariableIndex?.let { 1 } ?: 0) + 1, 0)
             if (indexVariableIndex != null) {
                 newEnv.variableTable[newFrameIndex][indexVariableIndex] = LocalVariable(FluoriteInt(0))
             }

--- a/src/commonMain/kotlin/mirrg/xarpite/operations/Runners.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/operations/Runners.kt
@@ -39,7 +39,7 @@ class TryCatchWithVariableRunner(private val leftRunners: List<Runner>, private 
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            val newEnv = Environment(env, 1, 0)
+            val newEnv = Environment(env.context, env, 1, 0)
             newEnv.variableTable[newFrameIndex][argumentVariableIndex] = LocalVariable(e.toFluoriteValue())
             rightRunners.forEach {
                 it.evaluate(newEnv)
@@ -73,7 +73,7 @@ class TryCatchRunner(private val leftRunners: List<Runner>, private val rightRun
 class LabelRunner(private val frameIndex: Int, private val variableIndex: Int, private val name: String, private val runners: List<Runner>) : Runner {
     override suspend fun evaluate(env: Environment) {
         val label = Label(name)
-        val newEnv = Environment(env, 1, 0)
+        val newEnv = Environment(env.context, env, 1, 0)
         newEnv.variableTable[frameIndex][variableIndex] = label
         try {
             runners.forEach {

--- a/src/commonMain/kotlin/mirrg/xarpite/test/TestUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/test/TestUtil.kt
@@ -48,11 +48,11 @@ suspend fun CoroutineScope.evalEmbedded(src: String, ioContext: IoContext = Unsu
     }
 }
 
-suspend fun Evaluator.get(src: String) = this.get("test", src, false, RuntimeContext.SUPPORTED_API_VERSIONS.first)
+suspend fun Evaluator.get(src: String) = this.get("test", src, false)
 
-suspend fun Evaluator.getEmbedded(src: String) = this.get("test", src, true, RuntimeContext.SUPPORTED_API_VERSIONS.first)
+suspend fun Evaluator.getEmbedded(src: String) = this.get("test", src, true)
 
-suspend fun Evaluator.run(src: String) = this.run("test", src, false, RuntimeContext.SUPPORTED_API_VERSIONS.first)
+suspend fun Evaluator.run(src: String) = this.run("test", src, false)
 
 val FluoriteValue.int get() = (this as FluoriteInt).value
 val FluoriteValue.big get() = (this as FluoriteBig).value


### PR DESCRIPTION
#269 の差分には、配線のリファクタリング成分と、デフォルトインデントの機能変更成分が混在していたのだ。[このコメント](https://github.com/MirrgieRiana/xarpite/pull/269#issuecomment-4775579971)の依頼に基づいて、配線のリファクタリング成分のみをこのPRに分離したのだ〜🌱

## 内容なのだ

`RuntimeContext` を `Evaluator` のコンストラクタ引数として受け取り、さらに `Environment` の第1引数として評価木全体から参照できるようにする配線なのだ。これに伴って、`Evaluator.get` / `Evaluator.run` に明示的に渡していた `apiVersion` 引数を取り除き、`context.apiVersion` を文法に渡すように整理したのだ。

本番の挙動は変わらないのだ。CLI やモジュール評価では元々 `context.apiVersion` を `get` / `run` に渡していたため、その値の出どころが `context` に一本化されるだけなのだっ。

## 変えるファイルなのだ

- `src/commonMain/kotlin/mirrg/xarpite/Evaluator.kt` — `Evaluator` が `RuntimeContext` を保持し、`apiVersion` 引数を除去するのだ
- `src/commonMain/kotlin/mirrg/xarpite/Frame.kt` — `Environment` の第1引数に `RuntimeContext` を追加するのだ
- `src/commonMain/kotlin/mirrg/xarpite/operations/Getters.kt` ・ `Runners.kt` — `Environment` の生成箇所に `context` を渡すのだ
- `src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt` ・ `cli/ModuleMounts.kt` ・ `browser/src/jsMain/kotlin/mirrg/xarpite/js/browser/JsBrowserMain.kt` — 呼び出し側の追従なのだ
- `src/commonMain/kotlin/mirrg/xarpite/test/TestUtil.kt` — テストヘルパーの追従なのだ
- `changelog.d/refactor-environment-runtime-context.md` — 内部変更につき本文の無い断片なのだ