### PR TITLE
CODE_POINTD を追加しちゃうのだっ！

### DIFF
--- a/changelog.d/add-code-pointd-function.md
+++ b/changelog.d/add-code-pointd-function.md
@@ -1,0 +1,1 @@
+Added `CODE_POINTD` function that returns the string consisting of a single Unicode code point for a code point value.

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -540,9 +540,11 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CODE_POINT(char: STRING): INT`
 
+`CODE_POINTD(codePoint: INT): STRING`
+
 These functions convert between strings and character codes.
 
-The `CHAR_CODE` family works in UTF-16 code units, whereas `CODE_POINT` treats a character represented by a surrogate pair (U+10000 and above) as a single Unicode code point.
+The `CHAR_CODE` family works in UTF-16 code units, whereas the `CODE_POINT` family treats a character represented by a surrogate pair (U+10000 and above) as a single Unicode code point.
 
 Functions with the `D` suffix decode, while those without it encode.
 
@@ -553,10 +555,12 @@ Functions with the `D` suffix decode, while those without it encode.
 | `CHAR_CODES`  | `STREAM<INT>`   | value of each code unit | ← to code   | `STRING`         | string                         |
 | `CHAR_CODESD` | `STREAM<INT>`   | value of each code unit | → to string | `STRING`         | string                         |
 | `CODE_POINT`  | `INT`           | code point value        | ← to code   | `STRING`         | exactly one Unicode code point |
+| `CODE_POINTD` | `INT`           | code point value        | → to string | `STRING`         | exactly one Unicode code point |
 
 An error is raised for inputs that fall under any of the following:
 
 - `CHAR_CODED` `CHAR_CODESD`: given a value that is not between 0 and 65535
+- `CODE_POINTD`: given a value that is not between 0 and 1114111, or a surrogate code point (U+D800 to U+DFFF)
 - `CHAR_CODE` `CODE_POINT`: given a string that does not consist of exactly one code unit or code point, respectively
 - `CODE_POINT`: given a string that contains an isolated surrogate
 
@@ -587,6 +591,12 @@ $ xa 'CODE_POINT("A")'
 
 $ xa 'CODE_POINT("🍰")'
 # 127856
+
+$ xa 'CODE_POINTD(65)'
+# A
+
+$ xa 'CODE_POINTD(127856)'
+# 🍰
 ```
 
 ## `UC` Convert to Uppercase

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -540,9 +540,11 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 
 `CODE_POINT(char: STRING): INT`
 
+`CODE_POINTD(codePoint: INT): STRING`
+
 文字列と文字コードを相互に変換します。
 
-`CHAR_CODE` 系はUTF-16コード単位を単位とし、`CODE_POINT` はサロゲートペアで表される文字（U+10000以上）を1個のUnicodeコードポイントとして扱います。
+`CHAR_CODE` 系はUTF-16コード単位を単位とし、`CODE_POINT` 系はサロゲートペアで表される文字（U+10000以上）を1個のUnicodeコードポイントとして扱います。
 
 末尾に `D` が付く関数はデコード、付かない関数はエンコードに対応します。
 
@@ -553,10 +555,12 @@ $ xa '"-ab--ab-"::replace(/[a-z]{2}/g; m -> m.0 * 2)'
 | `CHAR_CODES`  | `STREAM<INT>`  | 各コード単位の数値   | ← コード化 | `STRING`       | 文字列                         |
 | `CHAR_CODESD` | `STREAM<INT>`  | 各コード単位の数値   | → 文字列化 | `STRING`       | 文字列                         |
 | `CODE_POINT`  | `INT`          | コードポイントの数値 | ← コード化 | `STRING`       | 丁度1個のUnicodeコードポイント |
+| `CODE_POINTD` | `INT`          | コードポイントの数値 | → 文字列化 | `STRING`       | 丁度1個のUnicodeコードポイント |
 
 次のいずれかに該当する入力に対しては、エラーになります。
 
 - `CHAR_CODED` `CHAR_CODESD`: 0以上65535以下でない数値を与えた場合
+- `CODE_POINTD`: 0以上1114111以下でない数値、またはサロゲートコードポイント（U+D800～U+DFFF）を与えた場合
 - `CHAR_CODE` `CODE_POINT`: コード単位またはコードポイントが丁度1個でない文字列を与えた場合
 - `CODE_POINT`: 孤立サロゲートを含む文字列を与えた場合
 
@@ -587,6 +591,12 @@ $ xa 'CODE_POINT("A")'
 
 $ xa 'CODE_POINT("🍰")'
 # 127856
+
+$ xa 'CODE_POINTD(65)'
+# A
+
+$ xa 'CODE_POINTD(127856)'
+# 🍰
 ```
 
 ## `UC` 大文字に変換

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -95,7 +95,7 @@ fun createStringMounts(): List<Map<String, Mount>> {
             if (arguments.size != 1) usage("CODE_POINTD(codePoint: INT): STRING")
             val codePoint = arguments[0].toFluoriteNumber(null).roundToInt()
             if (codePoint < 0 || codePoint > 0x10FFFF) throw FluoriteException("Argument must be between 0 and 1114111, got $codePoint".toFluoriteString())
-            if (codePoint in 0xD800..0xDFFF) throw FluoriteException("Surrogate code points are not allowed, got $codePoint".toFluoriteString())
+            if (codePoint in 0xD800..0xDFFF) throw FluoriteException("Argument must not be a surrogate code point, got $codePoint".toFluoriteString())
             val string = if (codePoint < 0x10000) {
                 codePoint.toChar().toString()
             } else {

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -91,6 +91,21 @@ fun createStringMounts(): List<Map<String, Mount>> {
             }
             FluoriteInt(codePoint)
         },
+        "CODE_POINTD" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("CODE_POINTD(codePoint: INT): STRING")
+            val codePoint = arguments[0].toFluoriteNumber(null).roundToInt()
+            if (codePoint < 0 || codePoint > 0x10FFFF) throw FluoriteException("Argument must be between 0 and 1114111, got $codePoint".toFluoriteString())
+            if (codePoint in 0xD800..0xDFFF) throw FluoriteException("Surrogate code points are not allowed, got $codePoint".toFluoriteString())
+            val string = if (codePoint < 0x10000) {
+                codePoint.toChar().toString()
+            } else {
+                val offset = codePoint - 0x10000
+                val high = 0xD800 + (offset shr 10)
+                val low = 0xDC00 + (offset and 0x3FF)
+                "${high.toChar()}${low.toChar()}"
+            }
+            string.toFluoriteString()
+        },
 
         *run {
             fun create(signature: String): FluoriteFunction {

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -192,5 +192,15 @@ class StringMountsTest {
         assertFailsWith<FluoriteException> { eval("CODE_POINT('\uDC00')") } // 孤立下位サロゲートはエラー
         // 長さ2でも正しいサロゲートペアでない並びはエラー
         assertFailsWith<FluoriteException> { eval("CODE_POINT('\uD800A')") } // 上位サロゲートの後ろが下位サロゲートでないとエラー
+
+        // CODE_POINTD: コードポイントから文字列を返す
+        assertEquals("A", eval("CODE_POINTD(65)").string) // 65 は 'A'
+        assertEquals("\u3042", eval("CODE_POINTD(12354)").string) // 12354 は 'あ'
+        assertEquals("\uD83C\uDF70", eval("CODE_POINTD(127856)").string) // 127856 は 🍰
+
+        // CODE_POINTD: 範囲外の場合はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTD(-1)") } // 負数はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTD(1114112)") } // U+110000はエラー
+        assertFailsWith<FluoriteException> { eval("CODE_POINTD(55296)") } // サロゲートはエラー（U+D800）
     }
 }

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -202,5 +202,10 @@ class StringMountsTest {
         assertFailsWith<FluoriteException> { eval("CODE_POINTD(-1)") } // 負数はエラー
         assertFailsWith<FluoriteException> { eval("CODE_POINTD(1114112)") } // U+110000はエラー
         assertFailsWith<FluoriteException> { eval("CODE_POINTD(55296)") } // サロゲートはエラー（U+D800）
+
+        // CODE_POINTとCODE_POINTDは逆変換
+        assertEquals("A", eval("'A' >> CODE_POINT >> CODE_POINTD").string)
+        // サロゲートペアも往復できる
+        assertEquals("\uD83C\uDF70", eval("'\uD83C\uDF70' >> CODE_POINT >> CODE_POINTD").string)
     }
 }


### PR DESCRIPTION
Claude Fairyは https://github.com/MirrgieRiana/private/issues/16 に記載の Protocol 103F 必読なのだ

## 実装内容なのだ

Unicodeコードポイントの数値から、その文字の文字列を返す、以下の組み込み関数を追加するのだ〜♪

- `CODE_POINTD(codePoint: INT): STRING` — Unicodeコードポイントの数値（0〜1114111、サロゲートは除くのだ）から、1個のコードポイントからなる文字列を返すのだ

## 背景なのだ

[PR MirrgieRiana/xarpite#540](https://github.com/MirrgieRiana/xarpite/pull/540) は `CHAR_CODE` 系・`CODE_POINT` 系の合計8関数を一括で追加するものだったのだけど、レビューの負荷が大きくなりすぎたのだ。そこで、機能を小さく分割して、最新の `main` を起点に切り出すことにしたのだ〜。

このPRは、その分割の一環として、`CODE_POINTD` 1関数だけを切り出したものなのだ。`CODE_POINT` は [PR MirrgieRiana/xarpite#617](https://github.com/MirrgieRiana/xarpite/pull/617) で既に切り出し済みで、残りの `CODE_POINTS` / `CODE_POINTSD` は、後続の独立PRへ分離するのだ〜。

ドキュメントは、`main` で既に整えられている `CHAR_CODE` 系・`CODE_POINT` の表形式のセクションへ、`CODE_POINTD` を統合する形で記載しているのだ。

## 変更ファイルなのだ

- `src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt` — 実装なのだ
- `src/commonTest/kotlin/StringMountsTest.kt` — テストなのだ
- `pages/docs/ja/string.md` — 日本語ドキュメントなのだ
- `pages/docs/en/string.md` — 英語ドキュメントなのだ
- `changelog.d/add-code-pointd-function.md` — 更新履歴の断片なのだ