### PR TITLE
STREAM<T> | T のシグネチャ表記を STREAM<T> に簡約するのだ

### DIFF
--- a/changelog.d/simplify-stream-union-signature.md
+++ b/changelog.d/simplify-stream-union-signature.md
@@ -1,0 +1,1 @@
+?Simplified the redundant `T | STREAM<T>` notation to `STREAM<T>` in the usage signatures of the `KEYS`, `CSV`, `TSV`, `CSVD`, and `TSVD` functions.

--- a/pages/docs/en/builtin.md
+++ b/pages/docs/en/builtin.md
@@ -267,7 +267,7 @@ $ xa '"A\nB\nC\n" >> LINES >> LINESD >> JSON'
 
 ## `KEYS` Get Stream of Object Keys
 
-`KEYS(object: OBJECT | STREAM<OBJECT>): STREAM<STRING>`
+`KEYS(object: STREAM<OBJECT>): STREAM<STRING>`
 
 Returns a stream of keys from `object`.
 

--- a/pages/docs/en/data-conversion.md
+++ b/pages/docs/en/data-conversion.md
@@ -404,7 +404,7 @@ $ xa '
 
 ## `CSV` Convert Array to CSV String
 
-`CSV([separator: separator: STRING; ][quote: quote: STRING; ]value: ARRAY<STRING> | STREAM<ARRAY<STRING>>): STRING | STREAM<STRING>`
+`CSV([separator: separator: STRING; ][quote: quote: STRING; ]value: STREAM<ARRAY<STRING>>): STREAM<STRING>`
 
 Encodes an array of strings or a stream thereof into a CSV row string or a stream thereof.
 
@@ -460,7 +460,7 @@ $ xa ' [1;" \"2\" ",3] >> CSV '
 
 ## `CSVD` Convert CSV String to Array
 
-`CSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STRING | STREAM<STRING>): ARRAY<STRING> | STREAM<ARRAY<STRING>>`
+`CSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STREAM<STRING>): STREAM<ARRAY<STRING>>`
 
 Decodes a CSV row string or a stream thereof into an array of strings or a stream thereof.
 
@@ -499,12 +499,12 @@ $ xa ' " , 1 , , 3 , " >> CSVD >> JSON '
 
 ## `TSV` Convert Array to TSV String
 
-`TSV([separator: separator: STRING; ][quote: quote: STRING; ]value: ARRAY<STRING> | STREAM<ARRAY<STRING>>): STRING | STREAM<STRING>`
+`TSV([separator: separator: STRING; ][quote: quote: STRING; ]value: STREAM<ARRAY<STRING>>): STREAM<STRING>`
 
 Has the same behavior as the `CSV` function, but the default separator is the tab character `\t`.
 
 ## `TSVD` Convert TSV String to Array
 
-`TSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STRING | STREAM<STRING>): ARRAY<STRING> | STREAM<ARRAY<STRING>>`
+`TSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STREAM<STRING>): STREAM<ARRAY<STRING>>`
 
 Has the same behavior as the `CSVD` function, but the default separator is the tab character `\t`.

--- a/pages/docs/ja/builtin.md
+++ b/pages/docs/ja/builtin.md
@@ -267,7 +267,7 @@ $ xa '"A\nB\nC\n" >> LINES >> LINESD >> JSON'
 
 ## `KEYS` オブジェクトのキーのストリームを取得
 
-`KEYS(object: OBJECT | STREAM<OBJECT>): STREAM<STRING>`
+`KEYS(object: STREAM<OBJECT>): STREAM<STRING>`
 
 `object` のキーのストリームを返します。
 

--- a/pages/docs/ja/data-conversion.md
+++ b/pages/docs/ja/data-conversion.md
@@ -404,7 +404,7 @@ $ xa '
 
 ## `CSV` 配列をCSV文字列に変換
 
-`CSV([separator: separator: STRING; ][quote: quote: STRING; ]value: ARRAY<STRING> | STREAM<ARRAY<STRING>>): STRING | STREAM<STRING>`
+`CSV([separator: separator: STRING; ][quote: quote: STRING; ]value: STREAM<ARRAY<STRING>>): STREAM<STRING>`
 
 文字列の配列やそのストリームを、CSV行の文字列やそのストリームにエンコードします。
 
@@ -460,7 +460,7 @@ $ xa ' [1;" \"2\" ",3] >> CSV '
 
 ## `CSVD` CSV文字列を配列に変換
 
-`CSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STRING | STREAM<STRING>): ARRAY<STRING> | STREAM<ARRAY<STRING>>`
+`CSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STREAM<STRING>): STREAM<ARRAY<STRING>>`
 
 CSV行の文字列やそのストリームを、文字列の配列やそのストリームにデコードします。
 
@@ -499,12 +499,12 @@ $ xa ' " , 1 , , 3 , " >> CSVD >> JSON '
 
 ## `TSV` 配列をTSV文字列に変換
 
-`TSV([separator: separator: STRING; ][quote: quote: STRING; ]value: ARRAY<STRING> | STREAM<ARRAY<STRING>>): STRING | STREAM<STRING>`
+`TSV([separator: separator: STRING; ][quote: quote: STRING; ]value: STREAM<ARRAY<STRING>>): STREAM<STRING>`
 
 `CSV` 関数と同一の動作を持ちますが、区切り文字のデフォルトがタブ文字 `\t` です。
 
 ## `TSVD` TSV文字列を配列に変換
 
-`TSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STRING | STREAM<STRING>): ARRAY<STRING> | STREAM<ARRAY<STRING>>`
+`TSVD([separator: separator: STRING; ][quote: quote: STRING; ]lines: STREAM<STRING>): STREAM<ARRAY<STRING>>`
 
 `CSVD` 関数と同一の動作を持ちますが、区切り文字のデフォルトがタブ文字 `\t` です。

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
@@ -268,7 +268,7 @@ fun createDataConversionMounts(): List<Map<String, Mount>> {
         *run {
             fun create(name: String, defaultSeparator: String): FluoriteFunction {
                 return FluoriteFunction.immediate { arguments ->
-                    fun usage(): Nothing = usage("""$name([separator: separator: STRING; ][quote: quote: STRING; ]value: ARRAY<STRING> | STREAM<ARRAY<STRING>>): STRING | STREAM<STRING>""")
+                    fun usage(): Nothing = usage("""$name([separator: separator: STRING; ][quote: quote: STRING; ]value: STREAM<ARRAY<STRING>>): STREAM<STRING>""")
                     if (arguments.isEmpty()) usage()
                     val parameters = arguments.dropLast(1)
                         .associate {
@@ -341,7 +341,7 @@ fun createDataConversionMounts(): List<Map<String, Mount>> {
         *run {
             fun create(name: String, defaultSeparator: String): FluoriteFunction {
                 return FluoriteFunction.immediate { arguments ->
-                    fun usage(): Nothing = usage("""$name([separator: separator: STRING; ][quote: quote: STRING; ]lines: STRING | STREAM<STRING>): ARRAY<STRING> | STREAM<ARRAY<STRING>>""")
+                    fun usage(): Nothing = usage("""$name([separator: separator: STRING; ][quote: quote: STRING; ]lines: STREAM<STRING>): STREAM<ARRAY<STRING>>""")
                     if (arguments.isEmpty()) usage()
                     val parameters = arguments.dropLast(1)
                         .associate {

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
@@ -270,7 +270,7 @@ fun createStreamMounts(): List<Map<String, Mount>> {
             }
         },
         "KEYS" define FluoriteFunction.immediate { arguments ->
-            fun usage(): Nothing = usage("KEYS(object: OBJECT | STREAM<OBJECT>): STREAM<STRING>")
+            fun usage(): Nothing = usage("KEYS(object: STREAM<OBJECT>): STREAM<STRING>")
             if (arguments.size == 1) {
                 val obj = arguments[0]
                 if (obj is FluoriteStream) {


### PR DESCRIPTION
## 概要

`STREAM<T> | T` の形（リポジトリ上では `T | STREAM<T>` の並び）になっているシグネチャ表記を、冗長な単一値の選択肢を取り除いて `STREAM<T>` に簡約するのだ。

1要素のストリームとその唯一の要素は基本的に同一視される（`stream.md` 参照）ため、`STREAM<T>` の表記には既に単一値が含まれており、`| T` の部分は冗長なのだ。挙動は変わらず、表記の簡約のみなのだ。

## 対象

| 関数 | 変更前 | 変更後 |
|---|---|---|
| `KEYS` | `OBJECT \| STREAM<OBJECT>` | `STREAM<OBJECT>` |
| `CSV` / `TSV` | 引数 `ARRAY<STRING> \| STREAM<ARRAY<STRING>>` / 戻り `STRING \| STREAM<STRING>` | `STREAM<ARRAY<STRING>>` / `STREAM<STRING>` |
| `CSVD` / `TSVD` | 引数 `STRING \| STREAM<STRING>` / 戻り `ARRAY<STRING> \| STREAM<ARRAY<STRING>>` | `STREAM<STRING>` / `STREAM<ARRAY<STRING>>` |

ソースの `usage(...)` 文字列（エラーメッセージ）と、`ja` / `en` 両方のドキュメントのシグネチャ表記を対象とするのだ。

`UC` / `LC` の `... STRING | ... STREAM<STRING> ...` は型ユニオンではなくオーバーロード2連の表記であり、文字どおりの `STREAM<T> | T` には該当しないため対象外なのだ。

Closes #644

参考: #644 のコメントでの調査・依頼に基づくのだ。