### PR TITLE
比較演算子 `==` の内部識別子 `EQUAL` を `EQUAL_EQUAL` に揃えるのだ

### DIFF
--- a/src/commonMain/kotlin/mirrg/xarpite/Grammar.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Grammar.kt
@@ -265,7 +265,7 @@ class XarpiteGrammar(val location: String, val apiVersion: Int) {
     val spaceshipOperator: Parser<(Node, Node, Position) -> InfixNode> = -"<=>" map { ::InfixLessEqualGreaterNode }
     val spaceship: Parser<Node> = leftAssociative(match, -s * spaceshipOperator.result * -b) { left, operator, right -> operator.value(left, right, operator.position) }
     val comparisonOperator: Parser<ComparisonOperatorType> = or(
-        -"==" map { ComparisonOperatorType.EQUAL }, // ==
+        -"==" map { ComparisonOperatorType.EQUAL_EQUAL }, // ==
         -"!=" map { ComparisonOperatorType.EXCLAMATION_EQUAL }, // !=
         -">=" map { ComparisonOperatorType.GREATER_EQUAL }, // >=
         -'>' * !'>' map { ComparisonOperatorType.GREATER }, // >

--- a/src/commonMain/kotlin/mirrg/xarpite/Nodes.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Nodes.kt
@@ -97,7 +97,7 @@ enum class Side {
 }
 
 enum class ComparisonOperatorType {
-    EQUAL,
+    EQUAL_EQUAL,
     EXCLAMATION_EQUAL,
     GREATER,
     LESS,

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/GetterCompiler.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/GetterCompiler.kt
@@ -294,7 +294,7 @@ fun Frame.compileToGetter(node: Node): Getter {
             val termGetters = node.nodes.map { compileToGetter(it) }
             val operators: List<Comparator> = node.operators.map {
                 when (it.first) {
-                    ComparisonOperatorType.EQUAL -> EqualComparator(it.second)
+                    ComparisonOperatorType.EQUAL_EQUAL -> EqualComparator(it.second)
                     ComparisonOperatorType.EXCLAMATION_EQUAL -> NotEqualComparator(it.second)
                     ComparisonOperatorType.GREATER -> GreaterComparator(it.second)
                     ComparisonOperatorType.LESS -> LessComparator(it.second)


### PR DESCRIPTION
## 概要

比較演算子の内部識別子を表す列挙型 `ComparisonOperatorType`（`Nodes.kt`）のうち、`==` 用のメンバー `EQUAL` を、記号並びの命名規約に揃えて `EQUAL_EQUAL` にするのだ。

## 背景

`ComparisonOperatorType` の記号系メンバーは、`!=` を `EXCLAMATION_EQUAL` と呼ぶように、記号を1つずつ並べて命名する流儀なのだ。`==` は `=` が2つなので、この流儀だと `EQUAL_EQUAL` が一貫した名前になるのだ。`==` 用のメンバーだけ短縮された `EQUAL` のままだったので、ここを揃えるのだ。

PR #647（厳密一致 `===` / `!==` の追加）の議論 https://github.com/MirrgieRiana/xarpite/pull/647#issuecomment-4815498494 から派生した一貫性の改善なのだ。

## 変更内容

内部識別子のみのリネームで、言語の利用者から見える挙動は一切変わらないのだ。