### PR TITLE
cliEval が終了コードを返すようにするリファクタリングなのだ

### DIFF
--- a/node/src/jsMain/kotlin/mirrg/xarpite/js/node/JsNodeMain.kt
+++ b/node/src/jsMain/kotlin/mirrg/xarpite/js/node/JsNodeMain.kt
@@ -117,9 +117,10 @@ suspend fun main() {
             showVersion(ioContext)
             return@coroutineScope
         }
-        cliEval(ioContext, options) {
+        val exitCode = cliEval(ioContext, options) {
             createJsMounts()
         }
+        if (exitCode != 0) ioContext.exit(exitCode)
     }
 }
 

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
@@ -180,12 +180,12 @@ fun RuntimeContext.addDefaultIncPaths() {
     inc.values += "./.xarpite/lib".toFluoriteString()
 }
 
-suspend fun CoroutineScope.cliEval(ioContext: IoContext, options: Options, createExtraMounts: RuntimeContext.() -> List<Map<String, Mount>> = { emptyList() }) {
-    withEvaluator(ioContext) { context, evaluator ->
+suspend fun CoroutineScope.cliEval(ioContext: IoContext, options: Options, createExtraMounts: RuntimeContext.() -> List<Map<String, Mount>> = { emptyList() }): Int {
+    return withEvaluator(ioContext) { context, evaluator ->
         if (options.apiVersion != null) {
             if (options.apiVersion !in RuntimeContext.SUPPORTED_API_VERSIONS) {
                 context.io.err("ERROR: This runtime does not support API version ${options.apiVersion}".toFluoriteString())
-                return@withEvaluator
+                return@withEvaluator 0
             }
             context.apiVersion = options.apiVersion
         }
@@ -213,6 +213,7 @@ suspend fun CoroutineScope.cliEval(ioContext: IoContext, options: Options, creat
                     println(result.toFluoriteString(null))
                 }
             }
+            0
         } catch (e: FluoriteException) {
             context.io.err("ERROR: ${e.message}".toFluoriteString())
             e.stackTrace?.reversed()?.forEach { position ->
@@ -221,6 +222,7 @@ suspend fun CoroutineScope.cliEval(ioContext: IoContext, options: Options, creat
             if (options.verbose) {
                 context.io.err(e.stackTraceToString().toFluoriteString())
             }
+            0
         }
     }
 }

--- a/src/commonTest/kotlin/CliTest.kt
+++ b/src/commonTest/kotlin/CliTest.kt
@@ -3171,6 +3171,43 @@ class CliTest {
         )
     }
 
+    @Test
+    fun cliEvalReturnsZeroExitCodeOnSuccess() = runTest {
+        // cliEval は正常終了時に終了コード0を返す
+        val context = TestIoContext()
+        val options = Options(
+            src = "OUT('ok')",
+            arguments = emptyList(),
+            quiet = false,
+            verbose = false,
+            apiVersion = null,
+            scriptFile = null,
+            embedded = false,
+        )
+        val exitCode = cliEvalImpl(context, options)
+        assertEquals(0, exitCode)
+        assertEquals(null, context.exitCode)
+    }
+
+    @Test
+    fun cliEvalReturnsExitCodeWithoutCallingExitOnError() = runTest {
+        // cliEval はエラー終了時も終了コードを返すだけで、自身では exit を呼ばない（REPL 等での再利用のため）
+        val context = TestIoContext()
+        val options = Options(
+            src = "!! 'test error'",
+            arguments = emptyList(),
+            quiet = false,
+            verbose = false,
+            apiVersion = null,
+            scriptFile = null,
+            embedded = false,
+        )
+        val exitCode = cliEvalImpl(context, options)
+        assertEquals(0, exitCode)
+        assertEquals(null, context.exitCode)
+        assertTrue(context.stderrBytes.toUtf8String().contains("ERROR:"))
+    }
+
 }
 
 private suspend fun getAbsolutePath(file: okio.Path): String {

--- a/src/jvmMain/kotlin/JvmMain.kt
+++ b/src/jvmMain/kotlin/JvmMain.kt
@@ -54,6 +54,7 @@ fun main(args: Array<String>) {
             showVersion(ioContext)
             return@runBlocking
         }
-        cliEval(ioContext, options)
+        val exitCode = cliEval(ioContext, options)
+        if (exitCode != 0) ioContext.exit(exitCode)
     }
 }

--- a/src/linuxX64Main/kotlin/LinuxX64Main.kt
+++ b/src/linuxX64Main/kotlin/LinuxX64Main.kt
@@ -54,6 +54,7 @@ fun main(args: Array<String>) {
             showVersion(ioContext)
             return@runBlocking
         }
-        cliEval(ioContext, options)
+        val exitCode = cliEval(ioContext, options)
+        if (exitCode != 0) ioContext.exit(exitCode)
     }
 }


### PR DESCRIPTION
## 概要

`cliEval`（`src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt`）が、戻り値で終了コード（`Int`）を返すようにし、実際の `exit` の呼び出しを呼び出し側（`JvmMain` / `LinuxX64Main`）へ移すリファクタリングなのだ。

`cliEval` が内部で `exit` を直接呼ぶと、将来 `cliEval` を REPL などから再利用したときに、プロセスごと終了してしまう。代わりに `cliEval` は終了コードを返すだけにして、`exit` の判断は呼び出し側に委ねるようにするのだ。

これはユーザーから見える挙動を一切変えない純粋なリファクタリングで、`cliEval` は従来どおり常に終了コード 0 を返す。

## 背景

これは [PR #654](https://github.com/MirrgieRiana/xarpite/pull/654) から、純粋なリファクタリング部分のみを切り出したものなのだ。PR #654 本体は、API バージョン5でエラー終了時に非ゼロの終了コードを返す破壊的変更を扱っており、本 PR とは独立している。

文脈は [Issue #654 のコメント](https://github.com/MirrgieRiana/xarpite/pull/654#issuecomment-4818307475) を参照。

## このPRの作業範囲

- `cliEval` の戻り値を `Int`（終了コード）にする
- `exit` の呼び出しを呼び出し側（`JvmMain` / `LinuxX64Main`）へ移す
- テストコードの追加

---

🌱 このPRは [PR #654 のコメント](https://github.com/MirrgieRiana/xarpite/pull/654#issuecomment-4818307475)を起点に Claude Fairy が作成したのだ。