### PR TITLE
`FluoriteValue` を sealed にする参考用リファクタリングなのだ

### DIFF
--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
@@ -10,7 +10,7 @@ import mirrg.xarpite.toFluoriteIntAsCompared
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
-interface FluoriteNumber : FluoriteValue {
+sealed interface FluoriteNumber : FluoriteValue {
     fun toInt(): Int
     fun toDouble(): Double
     fun negate(): FluoriteNumber

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoritePlatformObject.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoritePlatformObject.kt
@@ -1,0 +1,6 @@
+package mirrg.xarpite.compilers.objects
+
+// sealed な FluoriteValue に対し、プラットフォーム固有のソースセット（jsMain の FluoriteJsObject など）から
+// 継承するための逃がし口。KMP では commonMain の sealed 型へ別ソースセットから直接サブタイプを足せないため、
+// commonMain 側に非 sealed な許可サブタイプを 1 枚挟む。
+abstract class FluoritePlatformObject : FluoriteValue

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
@@ -5,7 +5,7 @@ import mirrg.xarpite.Position
 import mirrg.xarpite.operations.FluoriteException
 import mirrg.xarpite.withStackTrace
 
-interface FluoriteValue {
+sealed interface FluoriteValue {
     companion object {
         // fluoriteクラスはlazyにしなければJSで初期化順序によるエラーが出る
         // https://youtrack.jetbrains.com/issue/KT-25796

--- a/src/jsMain/kotlin/mirrg/xarpite/js/JsObject.kt
+++ b/src/jsMain/kotlin/mirrg/xarpite/js/JsObject.kt
@@ -15,6 +15,7 @@ import mirrg.xarpite.compilers.objects.FluoriteInt
 import mirrg.xarpite.compilers.objects.FluoriteNull
 import mirrg.xarpite.compilers.objects.FluoriteNumber
 import mirrg.xarpite.compilers.objects.FluoriteObject
+import mirrg.xarpite.compilers.objects.FluoritePlatformObject
 import mirrg.xarpite.compilers.objects.FluoriteString
 import mirrg.xarpite.compilers.objects.FluoriteValue
 import mirrg.xarpite.compilers.objects.invokeImmediate
@@ -22,7 +23,7 @@ import mirrg.xarpite.compilers.objects.toFluoriteArray
 import mirrg.xarpite.compilers.objects.toFluoriteBoolean
 import mirrg.xarpite.compilers.objects.toFluoriteString
 
-class FluoriteJsObject(val value: dynamic) : FluoriteValue {
+class FluoriteJsObject(val value: dynamic) : FluoritePlatformObject() {
     companion object {
         val fluoriteClass by lazy {
             FluoriteObject(


### PR DESCRIPTION
## 概要

`FluoriteValue`（および sub-interface の `FluoriteNumber`）を `sealed` にするのだ。値型の集合を型レベルで閉じることで、`when` の網羅性をコンパイラに検査させられるようにするのだ。

これは [PR #647 のコメント](https://github.com/MirrgieRiana/xarpite/issues/647#issuecomment-4818313364) の依頼に基づく、今後のアプローチを検討するための参考用の実装なのだ。

## やったこと

- `interface FluoriteValue` → `sealed interface FluoriteValue`
- `interface FluoriteNumber` → `sealed interface FluoriteNumber`（`FluoriteInt` / `FluoriteDouble` / `FluoriteBig` を閉じる）
- commonMain に逃がし口の抽象クラス `FluoritePlatformObject` を新設し、jsMain の `FluoriteJsObject` をそこから継承させる

## 山場と設計判断

commonMain の `mirrg.xarpite.compilers.objects` にいる値型（`FluoriteInt` 〜 `FluoriteError` の具象14種）は、`FluoriteValue` と同一モジュール・同一パッケージなので、そのまま `sealed` の許可サブタイプになるのだ。

問題は `FluoriteJsObject`（jsMain・別パッケージ `mirrg.xarpite.js`）なのだ。KMP では、commonMain の `sealed` 型に対し、jsMain のような下位のソースセットから直接サブタイプを足せないのだ（JVM や native のコンパイル時にそのサブタイプが見えず、網羅が成立しなくなるため）。

そこで本実装では、commonMain 側に非 `sealed` な許可サブタイプ `FluoritePlatformObject` を1枚挟み、`FluoriteJsObject` にそれを継承させるアプローチを取ったのだ。

このアプローチのトレードオフは、`FluoriteValue` が完全には閉じず、プラットフォーム固有の値型のための「開いた1枠」が残ることなのだ。commonMain 側の `when` は、各値型に加えて `is FluoritePlatformObject` の枝を1つ持つことで網羅になるのだ。

## 影響範囲

- 純粋な内部リファクタリングで、言語の利用者から見える挙動は変わらないのだ。
- 既存の `when` 式（値として使う `when`）は、`sealed` 化前から `else` を必須とされていたため、今回の変更でそのまま通るのだ。

---

🌱 このPRは [PR #647 のコメント](https://github.com/MirrgieRiana/xarpite/issues/647#issuecomment-4818313364)を起点に Claude Fairy が作成したのだ。