### PR TITLE
strictEquals を各値型のオーバーライドに組み替えるのだ

### DIFF
--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteArray.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteArray.kt
@@ -180,6 +180,7 @@ class FluoriteArray(val values: MutableList<FluoriteValue>) : FluoriteValue {
 
     override fun toString() = "[${values.joinToString(";") { "$it" }}]"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun FluoriteArray() = FluoriteArray(mutableListOf())

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBlob.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBlob.kt
@@ -52,6 +52,7 @@ class FluoriteBlob @OptIn(ExperimentalUnsignedTypes::class) constructor(val valu
     @OptIn(ExperimentalUnsignedTypes::class)
     override fun toString() = "FluoriteBlob(size=${value.size})"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 @OptIn(ExperimentalUnsignedTypes::class)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBoolean.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBoolean.kt
@@ -20,6 +20,7 @@ enum class FluoriteBoolean(val value: Boolean) : FluoriteValue {
 
     override fun toString() = if (value) "TRUE" else "FALSE"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     fun not() = if (value) FALSE else TRUE
 }
 

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
@@ -29,6 +29,7 @@ class FluoriteError(val throwable: Throwable) : FluoriteValue {
 
     override fun toString() = throwable.message ?: throwable.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun Throwable.toFluoriteValue(): FluoriteValue = if (this is FluoriteException) this.value else FluoriteError(this)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteFunction.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteFunction.kt
@@ -33,6 +33,7 @@ class FluoriteFunction private constructor(private val function: suspend (Array<
     }
 
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 
     suspend fun call(arguments: Array<suspend () -> FluoriteValue>) = function(arguments)
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNull.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNull.kt
@@ -13,4 +13,5 @@ object FluoriteNull : FluoriteValue {
     }
     override val parent = fluoriteClass
     override fun toString() = "NULL"
+    override fun strictEquals(other: FluoriteValue) = this == other
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
@@ -66,6 +66,7 @@ data class FluoriteInt(val value: Int) : FluoriteNumber {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     override fun toInt() = value
     override fun toDouble() = value.toDouble()
     override fun negate() = FluoriteInt(-value)
@@ -115,6 +116,7 @@ data class FluoriteDouble(val value: Double) : FluoriteNumber {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     override fun toInt() = value.toBigDecimal().intValue(true)
     override fun toDouble() = value
     override fun negate() = FluoriteDouble(-value)
@@ -151,6 +153,7 @@ data class FluoriteBig(val value: BigInteger) : FluoriteNumber {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     override fun toInt() = value.intValue(true)
     override fun toDouble() = value.doubleValue(false)
     override fun negate() = FluoriteBig(value.negate())

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteObject.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteObject.kt
@@ -129,4 +129,5 @@ class FluoriteObject(override val parent: FluoriteObject?, val map: MutableMap<S
     }
 
     override fun toString() = "{${map.entries.joinToString(";") { "${it.key}:${it.value}" }}}"
+    override fun strictEquals(other: FluoriteValue) = this === other
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoritePromise.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoritePromise.kt
@@ -61,4 +61,5 @@ class FluoritePromise : FluoriteValue {
 
     override fun toString() = "PROMISE[state=${if (deferred.isCompleted) "completed" else "pending"}]"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
@@ -95,6 +95,7 @@ data class FluoriteRegex(val pattern: String, val flags: String?) : FluoriteValu
 
     override fun toString() = stringCache
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
 }
 
 fun String.toFluoriteRegex(flags: String? = null) = FluoriteRegex(this, flags)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteStream.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteStream.kt
@@ -81,6 +81,7 @@ class FluoriteStream(val flowProvider: suspend FlowCollector<FluoriteValue>.() -
     }
 
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun FluoriteStream(vararg values: FluoriteValue) = FluoriteStream {

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
@@ -219,6 +219,7 @@ data class FluoriteString(val value: String) : FluoriteValue {
 
     override fun toString() = value
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
 }
 
 fun String.toFluoriteString() = if (this.isEmpty()) FluoriteString.EMPTY else FluoriteString(this)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
@@ -26,6 +26,9 @@ interface FluoriteValue {
     }
 
     val parent: FluoriteObject?
+
+    // クラスが異なる場合は常に不一致とし、不変系の型は内容で、可変系の型はインスタンスで比較する
+    fun strictEquals(other: FluoriteValue): Boolean
 }
 
 fun FluoriteValue.instanceOf(clazz: FluoriteValue): Boolean {
@@ -35,27 +38,6 @@ fun FluoriteValue.instanceOf(clazz: FluoriteValue): Boolean {
         if (currentObject === clazz) return true
         currentObject = currentObject.parent
     }
-}
-
-// クラスが異なる場合は常に不一致とし、不変系の型は内容で、可変系の型はインスタンスで比較する
-fun FluoriteValue.strictEquals(other: FluoriteValue): Boolean {
-    when (this) {
-        is FluoriteInt -> return this == other
-        is FluoriteDouble -> return this == other
-        is FluoriteBig -> return this == other
-        is FluoriteString -> return this == other
-        is FluoriteBoolean -> return this == other
-        FluoriteNull -> return this == other
-        is FluoriteRegex -> return this == other
-        is FluoriteObject -> return this === other
-        is FluoriteArray -> return this === other
-        is FluoriteBlob -> return this === other
-        is FluoriteStream -> return this === other
-        is FluoritePromise -> return this === other
-        is FluoriteFunction -> return this === other
-        is FluoriteError -> return this === other
-    }
-    throw IllegalStateException("Unexpected FluoriteValue type: ${this::class}")
 }
 
 fun interface Callable {

--- a/src/commonMain/kotlin/mirrg/xarpite/operations/Comparators.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/operations/Comparators.kt
@@ -6,7 +6,6 @@ import mirrg.xarpite.compilers.objects.FluoriteValue
 import mirrg.xarpite.compilers.objects.compareTo
 import mirrg.xarpite.compilers.objects.contains
 import mirrg.xarpite.compilers.objects.instanceOf
-import mirrg.xarpite.compilers.objects.strictEquals
 
 // TODO
 class EqualComparator(private val position: Position) : Comparator {

--- a/src/jsMain/kotlin/mirrg/xarpite/js/JsObject.kt
+++ b/src/jsMain/kotlin/mirrg/xarpite/js/JsObject.kt
@@ -76,6 +76,7 @@ class FluoriteJsObject(val value: dynamic) : FluoriteValue {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun FluoriteFunction.toJsFunction(): dynamic {


### PR DESCRIPTION
## 概要

厳密一致 `===` / `!==` の内部実装である `strictEquals` を、`FluoriteValue` 上の `when` による集中分岐から、各値型がオーバーライドするメンバーメソッドへ組み替えるのだ。

PR #647（`===` / `!==` の追加）の派生で、そのブランチ `fairy/strict-equality` に向けたスタック PR なのだ。議論は https://github.com/MirrgieRiana/xarpite/issues/647#issuecomment-4820651915 を参照なのだ。

## やったこと

- `FluoriteValue` に抽象メンバー `fun strictEquals(other: FluoriteValue): Boolean` を追加するのだ。
- 拡張関数 `FluoriteValue.strictEquals` の `when` 集中分岐を削除するのだ。
- 各値型がそれをオーバーライドし、自身と同じクラスで、かつ厳密等価条件を満たす際に真を返すのだ。
  - 不変系（`INT` `DOUBLE` `BIG` `STRING` `BOOLEAN` `NULL` `REGEX`）は内容で比較（`this == other`）。
  - 可変系（`OBJECT` `ARRAY` `BLOB` `STREAM` `PROMISE` `FUNCTION` `ERROR`、および jsMain の `FluoriteJsObject`）はインスタンスで比較（`this === other`）。

ディスパッチを各型へ移したことで、`else` も到達不能末尾の `IllegalStateException` も不要になり、網羅の保証がコンパイラ側に移るのだ。挙動は従来どおりなのだ。

## 補足

従来の `when` には jsMain の `FluoriteJsObject` の枝が無く、`===` で比較されると `IllegalStateException` に落ちる状態だったのだ。メンバー化により各型が自前の判定を持つため、この箇所も自然に解消されるのだ。
