### PR TITLE
厳密等価メソッド `strictEquals` を各値型に追加するのだ

### DIFF
--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteArray.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteArray.kt
@@ -180,6 +180,7 @@ class FluoriteArray(val values: MutableList<FluoriteValue>) : FluoriteValue {
 
     override fun toString() = "[${values.joinToString(";") { "$it" }}]"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun FluoriteArray() = FluoriteArray(mutableListOf())

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBlob.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBlob.kt
@@ -52,6 +52,7 @@ class FluoriteBlob @OptIn(ExperimentalUnsignedTypes::class) constructor(val valu
     @OptIn(ExperimentalUnsignedTypes::class)
     override fun toString() = "FluoriteBlob(size=${value.size})"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 @OptIn(ExperimentalUnsignedTypes::class)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBoolean.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteBoolean.kt
@@ -20,6 +20,7 @@ enum class FluoriteBoolean(val value: Boolean) : FluoriteValue {
 
     override fun toString() = if (value) "TRUE" else "FALSE"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     fun not() = if (value) FALSE else TRUE
 }
 

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteError.kt
@@ -29,6 +29,7 @@ class FluoriteError(val throwable: Throwable) : FluoriteValue {
 
     override fun toString() = throwable.message ?: throwable.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun Throwable.toFluoriteValue(): FluoriteValue = if (this is FluoriteException) this.value else FluoriteError(this)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteFunction.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteFunction.kt
@@ -33,6 +33,7 @@ class FluoriteFunction private constructor(private val function: suspend (Array<
     }
 
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 
     suspend fun call(arguments: Array<suspend () -> FluoriteValue>) = function(arguments)
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNull.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNull.kt
@@ -13,4 +13,5 @@ object FluoriteNull : FluoriteValue {
     }
     override val parent = fluoriteClass
     override fun toString() = "NULL"
+    override fun strictEquals(other: FluoriteValue) = this == other
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteNumber.kt
@@ -66,6 +66,7 @@ data class FluoriteInt(val value: Int) : FluoriteNumber {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     override fun toInt() = value
     override fun toDouble() = value.toDouble()
     override fun negate() = FluoriteInt(-value)
@@ -115,6 +116,7 @@ data class FluoriteDouble(val value: Double) : FluoriteNumber {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     override fun toInt() = value.toBigDecimal().intValue(true)
     override fun toDouble() = value
     override fun negate() = FluoriteDouble(-value)
@@ -151,6 +153,7 @@ data class FluoriteBig(val value: BigInteger) : FluoriteNumber {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
     override fun toInt() = value.intValue(true)
     override fun toDouble() = value.doubleValue(false)
     override fun negate() = FluoriteBig(value.negate())

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteObject.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteObject.kt
@@ -129,4 +129,5 @@ class FluoriteObject(override val parent: FluoriteObject?, val map: MutableMap<S
     }
 
     override fun toString() = "{${map.entries.joinToString(";") { "${it.key}:${it.value}" }}}"
+    override fun strictEquals(other: FluoriteValue) = this === other
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoritePromise.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoritePromise.kt
@@ -61,4 +61,5 @@ class FluoritePromise : FluoriteValue {
 
     override fun toString() = "PROMISE[state=${if (deferred.isCompleted) "completed" else "pending"}]"
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
@@ -95,6 +95,7 @@ data class FluoriteRegex(val pattern: String, val flags: String?) : FluoriteValu
 
     override fun toString() = stringCache
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
 }
 
 fun String.toFluoriteRegex(flags: String? = null) = FluoriteRegex(this, flags)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteStream.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteStream.kt
@@ -81,6 +81,7 @@ class FluoriteStream(val flowProvider: suspend FlowCollector<FluoriteValue>.() -
     }
 
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun FluoriteStream(vararg values: FluoriteValue) = FluoriteStream {

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
@@ -219,6 +219,7 @@ data class FluoriteString(val value: String) : FluoriteValue {
 
     override fun toString() = value
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this == other
 }
 
 fun String.toFluoriteString() = if (this.isEmpty()) FluoriteString.EMPTY else FluoriteString(this)

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
@@ -26,6 +26,9 @@ interface FluoriteValue {
     }
 
     val parent: FluoriteObject?
+
+    // クラスが異なる場合は常に不一致とし、不変系の型は内容で、可変系の型はインスタンスで比較する
+    fun strictEquals(other: FluoriteValue): Boolean
 }
 
 fun FluoriteValue.instanceOf(clazz: FluoriteValue): Boolean {

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteValue.kt
@@ -27,7 +27,9 @@ interface FluoriteValue {
 
     val parent: FluoriteObject?
 
-    // クラスが異なる場合は常に不一致とし、不変系の型は内容で、可変系の型はインスタンスで比較する
+    /**
+     * クラスが異なる場合は常に不一致とし、そうでない場合、不変系の型は内容で、可変系の型はインスタンスで比較するのだ。
+     */
     fun strictEquals(other: FluoriteValue): Boolean
 }
 

--- a/src/jsMain/kotlin/mirrg/xarpite/js/JsObject.kt
+++ b/src/jsMain/kotlin/mirrg/xarpite/js/JsObject.kt
@@ -76,6 +76,7 @@ class FluoriteJsObject(val value: dynamic) : FluoriteValue {
 
     override fun toString() = value.toString()
     override val parent get() = fluoriteClass
+    override fun strictEquals(other: FluoriteValue) = this === other
 }
 
 fun FluoriteFunction.toJsFunction(): dynamic {


### PR DESCRIPTION
## 概要

各値型が自身の厳密等価判定を持つように、`FluoriteValue` に厳密等価メソッド `strictEquals` を追加するのだ。

これは厳密一致演算子 `===` / `!==` を追加する PR #647 から、`strictEquals` の実装そのものを分離して、先に独立して入れるための土台 PR なのだ。この PR には `===` / `!==` の演算子は含まず、`strictEquals` の機構だけを置くのだ。

議論の文脈は https://github.com/MirrgieRiana/xarpite/pull/647#issuecomment-4823851471 を参照するのだ。

## 仕様

`FluoriteValue` に抽象メンバー `fun strictEquals(other: FluoriteValue): Boolean` を追加し、各値型がそれをオーバーライドするのだ。クラスが異なる場合は常に不一致とし、不変系の型は内容で、可変系の型はインスタンスで比較するのだ。

| 値型 | クラス | 厳密等価判定 |
| --- | --- | --- |
| `INT` | `FluoriteInt` | 内容比較（`this == other`） |
| `DOUBLE` | `FluoriteDouble` | 内容比較（`this == other`） |
| `BIG` | `FluoriteBig` | 内容比較（`this == other`） |
| `STRING` | `FluoriteString` | 内容比較（`this == other`） |
| `BOOLEAN` | `FluoriteBoolean` | 内容比較（`this == other`） |
| `NULL` | `FluoriteNull` | 内容比較（`this == other`） |
| `REGEX` | `FluoriteRegex` | 内容比較（`this == other`） |
| `OBJECT` | `FluoriteObject` | インスタンス比較（`this === other`） |
| `ARRAY` | `FluoriteArray` | インスタンス比較（`this === other`） |
| `BLOB` | `FluoriteBlob` | インスタンス比較（`this === other`） |
| `STREAM` | `FluoriteStream` | インスタンス比較（`this === other`） |
| `PROMISE` | `FluoritePromise` | インスタンス比較（`this === other`） |
| `FUNCTION` | `FluoriteFunction` | インスタンス比較（`this === other`） |
| `ERROR` | `FluoriteError` | インスタンス比較（`this === other`） |
| （jsMain） | `FluoriteJsObject` | インスタンス比較（`this === other`） |

この PR の時点では `strictEquals` を呼び出す利用者向けの構文は無く、外部から観測可能な挙動は変わらないのだ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
