### PR TITLE
ストリームの要素間に区切りを挿入する `INTERSPERSE` 関数を追加するのだ

### DIFF
--- a/changelog.d/intersperse.md
+++ b/changelog.d/intersperse.md
@@ -1,0 +1,1 @@
+Added `INTERSPERSE` function that inserts a separator between the elements of a stream.

--- a/pages/docs/en/builtin.md
+++ b/pages/docs/en/builtin.md
@@ -112,6 +112,49 @@ $ xa '13, 21, 24, 33, 31, 34 >> DISTINCT[by: x -> x % 10]'
 # 24
 ```
 
+## `INTERSPERSE` Insert Separator Between Stream Elements
+
+`<T> INTERSPERSE(separator: STREAM<T>; stream: STREAM<T>): STREAM<T>`
+
+Returns a stream with the first argument separator inserted between each element of the second argument stream. The separator is inserted only between elements, not at the beginning or end.
+
+```shell
+$ xa 'INTERSPERSE("-"; "a", "b", "c")'
+# a
+# -
+# b
+# -
+# c
+```
+
+---
+
+The separator can be a stream of multiple elements, in which case it is inserted between each pair of elements as a whole.
+
+```shell
+$ xa 'INTERSPERSE("-", "-"; "a", "b", "c")'
+# a
+# -
+# -
+# b
+# -
+# -
+# c
+```
+
+---
+
+When used with partial application, it becomes easier to incorporate into pipe chains.
+
+```shell
+$ xa '1 .. 3 | _ * 10 >> INTERSPERSE[0]'
+# 10
+# 0
+# 20
+# 0
+# 30
+```
+
 ## `JOIN` Concatenate Stream into String
 
 `JOIN([separator: STRING; ]stream: STREAM<STRING>): STRING`

--- a/pages/docs/ja/builtin.md
+++ b/pages/docs/ja/builtin.md
@@ -112,6 +112,49 @@ $ xa '13, 21, 24, 33, 31, 34 >> DISTINCT[by: x -> x % 10]'
 # 24
 ```
 
+## `INTERSPERSE`ストリームの要素間に区切りを挿入
+
+`<T> INTERSPERSE(separator: STREAM<T>; stream: STREAM<T>): STREAM<T>`
+
+第2引数のストリームの各要素の間に第1引数のセパレータを挿入したストリームを返します。セパレータは要素と要素の間だけに挿入され、先頭や末尾には付きません。
+
+```shell
+$ xa 'INTERSPERSE("-"; "a", "b", "c")'
+# a
+# -
+# b
+# -
+# c
+```
+
+---
+
+セパレータは複数要素のストリームでもよく、その場合は各要素の間にまとめて挿入されます。
+
+```shell
+$ xa 'INTERSPERSE("-", "-"; "a", "b", "c")'
+# a
+# -
+# -
+# b
+# -
+# -
+# c
+```
+
+---
+
+部分適用とともに用いることで、パイプチェーンに組み込みやすくなります。
+
+```shell
+$ xa '1 .. 3 | _ * 10 >> INTERSPERSE[0]'
+# 10
+# 0
+# 20
+# 0
+# 30
+```
+
 ## `JOIN`ストリームを文字列に連結
 
 `JOIN([separator: STRING; ]stream: STREAM<STRING>): STRING`

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
@@ -174,6 +174,28 @@ fun createStreamMounts(): List<Map<String, Mount>> {
                 "UNIQ" define create("UNIQ"),
             )
         },
+        "INTERSPERSE" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 2) usage("<T> INTERSPERSE(separator: STREAM<T>; stream: STREAM<T>): STREAM<T>")
+            val separator = arguments[0]
+            val stream = arguments[1]
+
+            if (stream is FluoriteStream) {
+                FluoriteStream {
+                    val separators = if (separator is FluoriteStream) separator.toMutableList() else mutableListOf(separator)
+                    var isFirst = true
+                    stream.collect { item ->
+                        if (isFirst) {
+                            isFirst = false
+                        } else {
+                            separators.forEach { emit(it) }
+                        }
+                        emit(item)
+                    }
+                }
+            } else {
+                stream
+            }
+        },
         "JOIN" define FluoriteFunction.immediate { arguments ->
             val separator: String
             val stream: FluoriteValue

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt
@@ -25,6 +25,7 @@ import mirrg.xarpite.compilers.objects.collect
 import mirrg.xarpite.compilers.objects.colon
 import mirrg.xarpite.compilers.objects.compareTo
 import mirrg.xarpite.compilers.objects.consume
+import mirrg.xarpite.compilers.objects.consumeToMutableList
 import mirrg.xarpite.compilers.objects.invokeImmediate
 import mirrg.xarpite.compilers.objects.toBoolean
 import mirrg.xarpite.compilers.objects.toFlow
@@ -181,13 +182,14 @@ fun createStreamMounts(): List<Map<String, Mount>> {
 
             if (stream is FluoriteStream) {
                 FluoriteStream {
-                    val separators = if (separator is FluoriteStream) separator.toMutableList() else mutableListOf(separator)
+                    var separators: List<FluoriteValue>? = null
                     var isFirst = true
                     stream.collect { item ->
                         if (isFirst) {
                             isFirst = false
                         } else {
-                            separators.forEach { emit(it) }
+                            val separators2 = separators ?: separator.consumeToMutableList().also { separators = it }
+                            separators2.forEach { emit(it) }
                         }
                         emit(item)
                     }

--- a/src/commonTest/kotlin/StreamTest.kt
+++ b/src/commonTest/kotlin/StreamTest.kt
@@ -6,6 +6,7 @@ import mirrg.xarpite.test.empty
 import mirrg.xarpite.test.eval
 import mirrg.xarpite.test.int
 import mirrg.xarpite.test.stream
+import mirrg.xarpite.test.string
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -103,6 +104,19 @@ class StreamTest {
         } catch (e: FluoriteException) {
             // 期待通り
         }
+    }
+
+    @Test
+    fun intersperse() = runTest {
+        assertEquals("a,-,b,-,c", eval("""INTERSPERSE("-"; "a", "b", "c")""").stream()) // 各要素の間に区切りを挿入する
+        assertEquals("1,0,2,0,3", eval("INTERSPERSE(0; 1, 2, 3)").stream()) // 区切りは文字列以外の値でもよい
+        assertEquals("a,-,-,b,-,-,c", eval("""INTERSPERSE("-", "-"; "a", "b", "c")""").stream()) // 区切りは複数要素のストリームでもよい
+        assertEquals("a,b,c", eval("""INTERSPERSE(,; "a", "b", "c")""").stream()) // 区切りが空ストリームの場合は単純に連結する
+        assertEquals("a,-,b", eval("""INTERSPERSE("-"; "a", "b")""").stream()) // ストリームは2要素でもよい
+        assertEquals("a", eval("""INTERSPERSE("-"; "a",)""").stream()) // ストリームは1要素でもよい
+        assertEquals("", eval("""INTERSPERSE("-"; ,)""").stream()) // ストリームは空でもよい
+        assertEquals("a", eval("""INTERSPERSE("-"; "a")""").string) // ストリームは非ストリームでもよい
+        assertEquals("10,0,20,0,30", eval("1 .. 3 | _ * 10 >> INTERSPERSE[0]").stream()) // 部分適用でパイプチェーンに組み込める
     }
 
 }

--- a/src/commonTest/kotlin/StreamTest.kt
+++ b/src/commonTest/kotlin/StreamTest.kt
@@ -1,6 +1,7 @@
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mirrg.xarpite.operations.FluoriteException
+import mirrg.xarpite.test.array
 import mirrg.xarpite.test.double
 import mirrg.xarpite.test.empty
 import mirrg.xarpite.test.eval
@@ -117,6 +118,18 @@ class StreamTest {
         assertEquals("", eval("""INTERSPERSE("-"; ,)""").stream()) // ストリームは空でもよい
         assertEquals("a", eval("""INTERSPERSE("-"; "a")""").string) // ストリームは非ストリームでもよい
         assertEquals("10,0,20,0,30", eval("1 .. 3 | _ * 10 >> INTERSPERSE[0]").stream()) // 部分適用でパイプチェーンに組み込める
+        assertEquals("[]", eval("""
+            array := []
+            separator := 1 .. 1 | ( array::push << "s" ; "-" )
+            INTERSPERSE(separator; "a",) >> VOID
+            array
+        """).array()) // 区切りを挟む相手がいない場合は区切りのストリームを読み取らない
+        assertEquals("[s]", eval("""
+            array := []
+            separator := 1 .. 1 | ( array::push << "s" ; "-" )
+            INTERSPERSE(separator; "a", "b", "c") >> VOID
+            array
+        """).array()) // 区切りのストリームは一度だけ読み取ってキャッシュし、各すき間で使い回す
     }
 
 }


### PR DESCRIPTION
## 概要

ストリームの各要素の間に、固定の区切りを挿入した新しいストリームを返す `INTERSPERSE` 関数を追加するのだ。シグネチャは `<T> INTERSPERSE(separator: STREAM<T>; stream: STREAM<T>): STREAM<T>` なのだ。

- `stream` の各要素の間に `separator` を挿入したストリームを返すのだ。区切りは要素と要素の間だけに入り、先頭や末尾には付かないのだ。
- `separator` は `STREAM<T>` なのだ。単一の値を渡した場合は1要素のストリームとして扱われ、Haskell の `intersperse` と同じ感覚で書けるのだ。
- `separator` を複数要素のストリームにすると、各要素の間にその区切りがまとめて挿入されるのだ。
- `stream` が非ストリームなら、区切りを挟む相手がいないので、そのまま返すのだ。

```shell
$ xa 'INTERSPERSE("-"; "a", "b", "c")'
# a
# -
# b
# -
# c

$ xa '1 .. 3 | _ * 10 >> INTERSPERSE[0]'
# 10
# 0
# 20
# 0
# 30
```

水平線で Markdown 断片を区切って並べる、といった用途に役立つのだ。

## 変更点

- **`src/commonMain/kotlin/mirrg/xarpite/mounts/StreamMounts.kt`**: `INTERSPERSE` 関数を追加するのだ。`separator` を一度リストに汲んでから、`stream` の各要素の間に挿入する遅延ストリームを返すのだ。`stream` が非ストリームの場合はそのまま返すのだ。
- **`src/commonTest/kotlin/StreamTest.kt`**: 単一要素の区切り、複数要素の区切り、空の区切り、2要素・1要素・空・非ストリームの入力、区切りの文字列以外の値、部分適用の各ケースをテストするのだ。
- **`pages/docs/ja/builtin.md`, `pages/docs/en/builtin.md`**: `INTERSPERSE` の説明と使用例を、`JOIN` の直前に追記するのだ。
- **`changelog.d/intersperse.md`**: 更新履歴の断片を追加するのだ。

## 背景

このPRは [Issue #671](https://github.com/MirrgieRiana/xarpite/issues/671) の実装なのだ。「入力ストリームの各要素の間に固定の区切りを挟む」機能について、関数名を各言語の類似機能と照らし合わせて考察し、既存の `INTERCALATE`（配列版）と対をなす名前として `INTERSPERSE` を採用したのだ。

考察の経緯は [この考察コメント](https://github.com/MirrgieRiana/xarpite/issues/671#issuecomment-4880285077) を参照なのだ。

Closes #671
