### PR TITLE
パスからディレクトリ名とファイル名を取り出す `DIRNAME` / `FILENAME` 関数を追加するのだ

### DIFF
--- a/changelog.d/add-dirname-filename-functions.md
+++ b/changelog.d/add-dirname-filename-functions.md
@@ -1,0 +1,1 @@
+Added `DIRNAME` and `FILENAME` functions that extract the directory name and file name from a path string.

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -702,3 +702,68 @@ $ xa '"/home/apple/"::RESOLVE("../cherry/./Cherry.txt")'
 Using string concatenation like `"$PWD/file"` generates paths like `//file` for the root directory.
 
 Instead, use the `RESOLVE` function like `PWD::RESOLVE("file")`.
+
+## `DIRNAME` Getting the Directory Name
+
+`DIRNAME(path: STRING): STRING | NULL`
+
+`STRING::DIRNAME(): STRING | NULL`
+
+Extracts the directory portion from `path`.
+
+```shell
+$ xa 'DIRNAME("/home/apple/Apple.txt")'
+# /home/apple
+
+$ xa '"/home/apple/Apple.txt"::DIRNAME()'
+# /home/apple
+```
+
+---
+
+The path is not normalized (no flattening of `.` or `..`).
+
+Trailing slashes are ignored.
+
+```shell
+$ xa 'DIRNAME("/home/apple/")'
+# /home
+```
+
+---
+
+For a path that contains no directory separator, `.` (the current directory) is returned.
+
+```shell
+$ xa 'DIRNAME("Cherry.txt")'
+# .
+```
+
+---
+
+For terminal paths such as `/`, `.`, or `..`, from which no further directory can be traced, `NULL` is returned.
+
+## `FILENAME` Getting the File Name
+
+`FILENAME(path: STRING): STRING`
+
+`STRING::FILENAME(): STRING`
+
+Extracts the file name portion from `path`.
+
+```shell
+$ xa 'FILENAME("/home/apple/Apple.txt")'
+# Apple.txt
+
+$ xa '"/home/apple/Apple.txt"::FILENAME()'
+# Apple.txt
+```
+
+---
+
+Trailing slashes are ignored.
+
+```shell
+$ xa 'FILENAME("/home/apple/")'
+# apple
+```

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -705,9 +705,9 @@ Instead, use the `RESOLVE` function like `PWD::RESOLVE("file")`.
 
 ## `DIRNAME` Getting the Directory Name
 
-`DIRNAME(path: STRING): STRING | NULL`
+`DIRNAME(path: STRING): STRING`
 
-`STRING::DIRNAME(): STRING | NULL`
+`STRING::DIRNAME(): STRING`
 
 Extracts the directory portion from `path`.
 
@@ -741,7 +741,12 @@ $ xa 'DIRNAME("Cherry.txt")'
 
 ---
 
-For terminal paths such as `/`, `.`, or `..`, from which no further directory can be traced, `NULL` is returned.
+The parent of the root directory is the root directory itself.
+
+```shell
+$ xa 'DIRNAME("/")'
+# /
+```
 
 ## `FILENAME` Getting the File Name
 
@@ -760,6 +765,8 @@ $ xa '"/home/apple/Apple.txt"::FILENAME()'
 ```
 
 ---
+
+The path is not normalized (no flattening of `.` or `..`).
 
 Trailing slashes are ignored.
 

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -705,9 +705,9 @@ $ xa '"/home/apple/"::RESOLVE("../cherry/./Cherry.txt")'
 
 ## `DIRNAME`ディレクトリ名の取得
 
-`DIRNAME(path: STRING): STRING | NULL`
+`DIRNAME(path: STRING): STRING`
 
-`STRING::DIRNAME(): STRING | NULL`
+`STRING::DIRNAME(): STRING`
 
 `path`からディレクトリ部分を取り出します。
 
@@ -741,7 +741,12 @@ $ xa 'DIRNAME("Cherry.txt")'
 
 ---
 
-`/`や`.`、`..`のような、それ以上ディレクトリを辿れない末端のパスに対しては`NULL`を返します。
+ルートディレクトリの親はルートディレクトリ自身になります。
+
+```shell
+$ xa 'DIRNAME("/")'
+# /
+```
 
 ## `FILENAME`ファイル名の取得
 
@@ -760,6 +765,8 @@ $ xa '"/home/apple/Apple.txt"::FILENAME()'
 ```
 
 ---
+
+パスの正規化（`.`や`..`の平坦化）は行われません。
 
 末尾のスラッシュは無視されます。
 

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -702,3 +702,68 @@ $ xa '"/home/apple/"::RESOLVE("../cherry/./Cherry.txt")'
 `"$PWD/file"`のような文字列連結を使うと、ルートディレクトリに対して`//file`のようなパスが生成されます。
 
 代わりに`PWD::RESOLVE("file")`のように`RESOLVE`関数を使用してください。
+
+## `DIRNAME`ディレクトリ名の取得
+
+`DIRNAME(path: STRING): STRING | NULL`
+
+`STRING::DIRNAME(): STRING | NULL`
+
+`path`からディレクトリ部分を取り出します。
+
+```shell
+$ xa 'DIRNAME("/home/apple/Apple.txt")'
+# /home/apple
+
+$ xa '"/home/apple/Apple.txt"::DIRNAME()'
+# /home/apple
+```
+
+---
+
+パスの正規化（`.`や`..`の平坦化）は行われません。
+
+末尾のスラッシュは無視されます。
+
+```shell
+$ xa 'DIRNAME("/home/apple/")'
+# /home
+```
+
+---
+
+ディレクトリの区切りを含まないパスに対しては、カレントディレクトリを表す`.`を返します。
+
+```shell
+$ xa 'DIRNAME("Cherry.txt")'
+# .
+```
+
+---
+
+`/`や`.`、`..`のような、それ以上ディレクトリを辿れない末端のパスに対しては`NULL`を返します。
+
+## `FILENAME`ファイル名の取得
+
+`FILENAME(path: STRING): STRING`
+
+`STRING::FILENAME(): STRING`
+
+`path`からファイル名部分を取り出します。
+
+```shell
+$ xa 'FILENAME("/home/apple/Apple.txt")'
+# Apple.txt
+
+$ xa '"/home/apple/Apple.txt"::FILENAME()'
+# Apple.txt
+```
+
+---
+
+末尾のスラッシュは無視されます。
+
+```shell
+$ xa 'FILENAME("/home/apple/")'
+# apple
+```

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -4,7 +4,6 @@ import mirrg.xarpite.Mount
 import mirrg.xarpite.RuntimeContext
 import mirrg.xarpite.compilers.objects.FluoriteFunction
 import mirrg.xarpite.compilers.objects.FluoriteInt
-import mirrg.xarpite.compilers.objects.FluoriteNull
 import mirrg.xarpite.compilers.objects.FluoriteStream
 import mirrg.xarpite.compilers.objects.FluoriteString
 import mirrg.xarpite.compilers.objects.FluoriteValue
@@ -225,14 +224,14 @@ fun createStringMounts(): List<Map<String, Mount>> {
             fun create(signature: String): FluoriteValue {
                 return FluoriteFunction.immediate { arguments ->
                     if (arguments.size != 1) usage(signature)
-                    val path = arguments[0].toFluoriteString(null).value
-                    path.toPath().parent?.toString()?.toFluoriteString() ?: FluoriteNull
+                    val path = arguments[0].toFluoriteString(null).value.toPath()
+                    (path.parent?.toString() ?: if (path.isAbsolute) path.toString() else ".").toFluoriteString()
                 }
             }
             arrayOf(
-                "DIRNAME" define create("DIRNAME(path: STRING): STRING | NULL"),
+                "DIRNAME" define create("DIRNAME(path: STRING): STRING"),
                 "::DIRNAME" define fluoriteArrayOf(
-                    FluoriteString.fluoriteClass colon create("STRING::DIRNAME(): STRING | NULL"),
+                    FluoriteString.fluoriteClass colon create("STRING::DIRNAME(): STRING"),
                 ),
             )
         },

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt
@@ -4,6 +4,7 @@ import mirrg.xarpite.Mount
 import mirrg.xarpite.RuntimeContext
 import mirrg.xarpite.compilers.objects.FluoriteFunction
 import mirrg.xarpite.compilers.objects.FluoriteInt
+import mirrg.xarpite.compilers.objects.FluoriteNull
 import mirrg.xarpite.compilers.objects.FluoriteStream
 import mirrg.xarpite.compilers.objects.FluoriteString
 import mirrg.xarpite.compilers.objects.FluoriteValue
@@ -216,6 +217,38 @@ fun createStringMounts(): List<Map<String, Mount>> {
                 "RESOLVE" define create("RESOLVE(dir: STRING; file: STRING): STRING"),
                 "::RESOLVE" define fluoriteArrayOf(
                     FluoriteString.fluoriteClass colon create("STRING::RESOLVE(file: STRING): STRING"),
+                ),
+            )
+        },
+
+        *run {
+            fun create(signature: String): FluoriteValue {
+                return FluoriteFunction.immediate { arguments ->
+                    if (arguments.size != 1) usage(signature)
+                    val path = arguments[0].toFluoriteString(null).value
+                    path.toPath().parent?.toString()?.toFluoriteString() ?: FluoriteNull
+                }
+            }
+            arrayOf(
+                "DIRNAME" define create("DIRNAME(path: STRING): STRING | NULL"),
+                "::DIRNAME" define fluoriteArrayOf(
+                    FluoriteString.fluoriteClass colon create("STRING::DIRNAME(): STRING | NULL"),
+                ),
+            )
+        },
+
+        *run {
+            fun create(signature: String): FluoriteValue {
+                return FluoriteFunction.immediate { arguments ->
+                    if (arguments.size != 1) usage(signature)
+                    val path = arguments[0].toFluoriteString(null).value
+                    path.toPath().name.toFluoriteString()
+                }
+            }
+            arrayOf(
+                "FILENAME" define create("FILENAME(path: STRING): STRING"),
+                "::FILENAME" define fluoriteArrayOf(
+                    FluoriteString.fluoriteClass colon create("STRING::FILENAME(): STRING"),
                 ),
             )
         },

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -1,6 +1,7 @@
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mirrg.xarpite.operations.FluoriteException
+import mirrg.xarpite.test.boolean
 import mirrg.xarpite.test.eval
 import mirrg.xarpite.test.int
 import mirrg.xarpite.test.stream
@@ -127,6 +128,49 @@ class StringMountsTest {
 
         // 2段階の .. を含むパス
         assertEquals("/home/file.txt", eval("RESOLVE('/home/user/dir'; '../../file.txt')").string)
+    }
+
+    @Test
+    fun dirname() = runTest {
+        // 絶対パスのディレクトリ部分
+        assertEquals("/home/apple", eval("DIRNAME('/home/apple/Apple.txt')").string)
+
+        // 相対パスのディレクトリ部分
+        assertEquals("home/apple", eval("DIRNAME('home/apple/Apple.txt')").string)
+
+        // ルート直下のファイルはルートを返す
+        assertEquals("/", eval("DIRNAME('/Banana.txt')").string)
+
+        // 末尾のスラッシュは無視される
+        assertEquals("/home", eval("DIRNAME('/home/apple/')").string)
+
+        // ディレクトリの区切りを含まないパスはカレントディレクトリ . を返す
+        assertEquals(".", eval("DIRNAME('Cherry.txt')").string)
+
+        // 末端のパスは NULL を返す
+        assertEquals(true, eval("DIRNAME('/') == NULL").boolean)
+        assertEquals(true, eval("DIRNAME('..') == NULL").boolean)
+
+        // 拡張関数版
+        assertEquals("/home/apple", eval("'/home/apple/Apple.txt'::DIRNAME()").string)
+    }
+
+    @Test
+    fun filename() = runTest {
+        // 絶対パスのファイル名部分
+        assertEquals("Apple.txt", eval("FILENAME('/home/apple/Apple.txt')").string)
+
+        // 相対パスのファイル名部分
+        assertEquals("Apple.txt", eval("FILENAME('home/apple/Apple.txt')").string)
+
+        // 単一の要素はそのまま返す
+        assertEquals("Cherry.txt", eval("FILENAME('Cherry.txt')").string)
+
+        // 末尾のスラッシュは無視される
+        assertEquals("apple", eval("FILENAME('/home/apple/')").string)
+
+        // 拡張関数版
+        assertEquals("Apple.txt", eval("'/home/apple/Apple.txt'::FILENAME()").string)
     }
 
     @Test

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -149,6 +149,7 @@ class StringMountsTest {
 
         // 末端のパスは NULL を返す
         assertEquals(true, eval("DIRNAME('/') == NULL").boolean)
+        assertEquals(true, eval("DIRNAME('.') == NULL").boolean)
         assertEquals(true, eval("DIRNAME('..') == NULL").boolean)
 
         // 拡張関数版

--- a/src/commonTest/kotlin/StringMountsTest.kt
+++ b/src/commonTest/kotlin/StringMountsTest.kt
@@ -144,13 +144,16 @@ class StringMountsTest {
         // 末尾のスラッシュは無視される
         assertEquals("/home", eval("DIRNAME('/home/apple/')").string)
 
+        // 正規化は行われない
+        assertEquals("a/b/..", eval("DIRNAME('a/b/../c.txt')").string)
+
         // ディレクトリの区切りを含まないパスはカレントディレクトリ . を返す
         assertEquals(".", eval("DIRNAME('Cherry.txt')").string)
+        assertEquals(".", eval("DIRNAME('.')").string)
+        assertEquals(".", eval("DIRNAME('..')").string)
 
-        // 末端のパスは NULL を返す
-        assertEquals(true, eval("DIRNAME('/') == NULL").boolean)
-        assertEquals(true, eval("DIRNAME('.') == NULL").boolean)
-        assertEquals(true, eval("DIRNAME('..') == NULL").boolean)
+        // ルートディレクトリの親はルートディレクトリ自身
+        assertEquals("/", eval("DIRNAME('/')").string)
 
         // 拡張関数版
         assertEquals("/home/apple", eval("'/home/apple/Apple.txt'::DIRNAME()").string)
@@ -169,6 +172,9 @@ class StringMountsTest {
 
         // 末尾のスラッシュは無視される
         assertEquals("apple", eval("FILENAME('/home/apple/')").string)
+
+        // 正規化は行われない
+        assertEquals("..", eval("FILENAME('a/b/..')").string)
 
         // 拡張関数版
         assertEquals("Apple.txt", eval("'/home/apple/Apple.txt'::FILENAME()").string)


### PR DESCRIPTION
Closes #385

パスからディレクトリ部分とファイル名部分を取り出す組み込み関数 `DIRNAME` / `FILENAME` を追加するのだぁ〜🌱

このタスクは https://github.com/MirrgieRiana/xarpite/issues/385#issuecomment-4880302588 で依頼されたものなのだぁ。

## 仕様

- `DIRNAME(path: STRING): STRING` / `STRING::DIRNAME(): STRING`
  - パスからディレクトリ部分を取り出すのだぁ。
  - ディレクトリの区切りを含まないパス（`"Cherry.txt"` や `"."`、`".."` など）に対しては、カレントディレクトリを表す `"."` を返すのだぁ。
  - ルートディレクトリ `"/"` の親はルートディレクトリ自身 `"/"` になるのだぁ。
- `FILENAME(path: STRING): STRING` / `STRING::FILENAME(): STRING`
  - パスからファイル名部分を取り出すのだぁ。

どちらもパスの正規化（`.` や `..` の平坦化）は行わず、末尾のスラッシュは無視するのだぁ。実装は既存の `RESOLVE` 関数と同じく okio の `Path` を使っているのだぁ〜🌱

## `DIRNAME` の戻り値についての設計調査

親ディレクトリを持たないパス（`"Cherry.txt"` や `"/"` など）に対して何を返すべきか、様々な言語の parent / dirname 操作の挙動を調査したのだぁ〜🌱

| 言語 / API | `Cherry.txt` | `/` | `.` | `..` |
|---|---|---|---|---|
| coreutils `dirname` | `.` | `/` | `.` | `.` |
| Node `path.dirname` | `.` | `/` | `.` | `.` |
| Ruby `File.dirname` | `.` | `/` | `.` | `.` |
| Perl `dirname` | `.` | `/` | `.` | `.` |
| Go `filepath.Dir` | `.` | `/` | `.` | `.` |
| Python `pathlib` `.parent` | `.` | `/` | `.` | `.` |
| Python `os.path.dirname` | `""` | `/` | `""` | `""` |
| Java `Path.getParent` | `null` | `null` | `null` | `null` |
| Rust `Path::parent` | `Some("")` | `None` | `Some("")` | `Some("")` |

（Go・Rust は公式ソースのドキュメントコメントによる裏取り、それ以外はこのPRの作業環境で実測したのだぁ）

一般的な挙動は大きく3系統に分かれるのだぁ〜🌱

- **`.` / `/` を返し、`null` を返さない系**（coreutils dirname, Node, Ruby, Perl, Go, Python pathlib）
- **空文字列を返す系**（Python os.path.dirname）
- **`null` / `None` を返す navigation 系**（Java `getParent`, Rust `parent`）

「`dirname`」という名前を持つ操作は、Python `os.path` を除いてほぼすべて「区切りを含まないパスには `.`、ルートにはルート自身 `/` を返し、`null` は返さない」という挙動に集中しているのだぁ〜🌱 `null` を返すのは「`getParent`」「`parent`」という木構造のノード遷移を表す API に限られるのだぁ。

この調査を踏まえて、`DIRNAME` は Unix の `dirname` コマンド由来の名前であることに合わせて、**`STRING`（`NULL` なし）を返し、区切りを含まないパスには `.`、ルートにはルート自身 `/` を返す**設計にしたのだぁ〜🌱 これで戻り値型が `STRING | NULL` から `STRING` に単純化されて、`"Cherry.txt"` には `.` を返すのに `"."` には `NULL` を返す、という非対称も解消されるのだぁ✨

## 変更点

- `DIRNAME` / `FILENAME` を `src/commonMain/kotlin/mirrg/xarpite/mounts/StringMounts.kt` に追加
- テストを `src/commonTest/kotlin/StringMountsTest.kt` に追加
- ドキュメントを `pages/docs/ja/string.md` および `pages/docs/en/string.md` に追加
- `changelog.d` に断片ファイルを追加
