### PR TITLE
正規表現のフラグ操作 API `withFlag` / `withoutFlag` / `+` / `-` を追加するのだ

### DIFF
--- a/changelog.d/add-regex-with-flag.md
+++ b/changelog.d/add-regex-with-flag.md
@@ -1,0 +1,3 @@
+Added `REGEX::withFlag` method that returns a regular expression with the given flag added or removed.
+Added `REGEX::withoutFlag` method that returns a regular expression with the given flag removed.
+Added `+` and `-` operators for regular expressions that add or remove a flag.

--- a/pages/docs/en/regex.md
+++ b/pages/docs/en/regex.md
@@ -100,6 +100,57 @@ $ xa '/apple/.flags'
 # NULL
 ```
 
+# Flag Manipulation of Regular Expression Objects
+
+From a regular expression object, you can obtain a new regular expression object with a flag added or removed.
+
+`REGEX::withFlag(flag: STRING[; enable: BOOLEAN]): REGEX`
+
+`withFlag` returns a regular expression object with each flag character contained in `flag` added.
+
+If `enable` is `FALSE`, removal is performed instead of addition. `enable` defaults to `TRUE`.
+
+The following are all shorthands for the base form using `withFlag`:
+
+| Notation                   | Base Form                      |
+|----------------------------|--------------------------------|
+| `regex::withoutFlag(flag)` | `regex::withFlag(flag; FALSE)` |
+| `regex + flag`             | `regex::withFlag(flag; TRUE)`  |
+| `regex - flag`             | `regex::withFlag(flag; FALSE)` |
+
+These operations are idempotent. Adding a flag that is already present, or removing a flag that is not present, does not change the result.
+
+`flag` can contain multiple flag characters at once, such as `gi`.
+
+Added flags are not normalized and are always appended to the end of the existing flag sequence.
+
+When all flags are removed, `flags` becomes `NULL`.
+
+If `flag` contains a character that is invalid as a regular expression flag, an error occurs.
+
+```shell
+$ xa ' /apple/::withFlag("g") '
+# /apple/g
+
+$ xa ' /apple/g::withFlag("g"; FALSE) '
+# /apple/
+
+$ xa ' /apple/::withoutFlag("i") '
+# /apple/
+
+$ xa ' /apple/ + "i" '
+# /apple/i
+
+$ xa ' /apple/gi - "g" '
+# /apple/i
+
+$ xa ' /apple/i::withFlag("g") '
+# /apple/ig
+
+$ xa ' /apple/::withFlag("gi") '
+# /apple/gi
+```
+
 # Partial Match Determination
 
 The `regex @ string` operator can determine whether a regular expression partially matches a string.

--- a/pages/docs/ja/regex.md
+++ b/pages/docs/ja/regex.md
@@ -100,6 +100,57 @@ $ xa '/apple/.flags'
 # NULL
 ```
 
+# 正規表現オブジェクトのフラグ操作
+
+正規表現オブジェクトから、フラグを付与または除去した新しい正規表現オブジェクトを得ることができます。
+
+`REGEX::withFlag(flag: STRING[; enable: BOOLEAN]): REGEX`
+
+`withFlag`は、`flag`に含まれる各フラグ文字を付与した正規表現オブジェクトを返します。
+
+`enable`を`FALSE`にした場合は、付与ではなく除去を行います。`enable`は省略時`TRUE`です。
+
+以下は、いずれも`withFlag`を用いた基本形の略記です。
+
+| 記法                       | 基本形                          |
+|--------------------------|------------------------------|
+| `regex::withoutFlag(flag)` | `regex::withFlag(flag; FALSE)` |
+| `regex + flag`           | `regex::withFlag(flag; TRUE)`  |
+| `regex - flag`           | `regex::withFlag(flag; FALSE)` |
+
+これらの操作は冪等です。既に付与されているフラグの付与や、付与されていないフラグの除去は、結果を変えません。
+
+`flag`には、`gi`のように複数のフラグ文字をまとめて記述できます。
+
+付与されるフラグは正規化されず、常に既存のフラグ列の末尾に追記されます。
+
+すべてのフラグが除去された場合、`flags`は`NULL`になります。
+
+`flag`に正規表現のフラグとして不正な文字が含まれる場合、エラーになります。
+
+```shell
+$ xa ' /apple/::withFlag("g") '
+# /apple/g
+
+$ xa ' /apple/g::withFlag("g"; FALSE) '
+# /apple/
+
+$ xa ' /apple/::withoutFlag("i") '
+# /apple/
+
+$ xa ' /apple/ + "i" '
+# /apple/i
+
+$ xa ' /apple/gi - "g" '
+# /apple/i
+
+$ xa ' /apple/i::withFlag("g") '
+# /apple/ig
+
+$ xa ' /apple/::withFlag("gi") '
+# /apple/gi
+```
+
 # 部分一致判定
 
 `regex @ string`演算子で、文字列に正規表現が部分一致するか否かを判定できます。

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
@@ -38,6 +38,29 @@ data class FluoriteRegex(val pattern: String, val flags: String?) : FluoriteValu
                         val string = arguments[1].toFluoriteString(null).value
                         regex.matchImpl(string)
                     },
+                    "withFlag" to FluoriteFunction.immediate { arguments ->
+                        val regex = arguments[0] as FluoriteRegex
+                        when (arguments.size) {
+                            2 -> regex.withFlag(arguments[1].toFluoriteString(null).value, true)
+                            3 -> regex.withFlag(arguments[1].toFluoriteString(null).value, arguments[2].toBoolean(null))
+                            else -> throw FluoriteException("Usage: REGEX::withFlag(flag: STRING[; enable: BOOLEAN]): REGEX".toFluoriteString())
+                        }
+                    },
+                    "withoutFlag" to FluoriteFunction.immediate { arguments ->
+                        val regex = arguments[0] as FluoriteRegex
+                        val flag = arguments[1].toFluoriteString(null).value
+                        regex.withFlag(flag, false)
+                    },
+                    OperatorMethod.PLUS.methodName to FluoriteFunction.immediate { arguments ->
+                        val regex = arguments[0] as FluoriteRegex
+                        val flag = arguments[1].toFluoriteString(null).value
+                        regex.withFlag(flag, true)
+                    },
+                    OperatorMethod.MINUS.methodName to FluoriteFunction.immediate { arguments ->
+                        val regex = arguments[0] as FluoriteRegex
+                        val flag = arguments[1].toFluoriteString(null).value
+                        regex.withFlag(flag, false)
+                    },
                     OperatorMethod.MATCH.methodName to FluoriteFunction.immediate { arguments ->
                         val regex = arguments[0] as FluoriteRegex
                         val string = arguments[1].toFluoriteString(null).value
@@ -79,6 +102,23 @@ data class FluoriteRegex(val pattern: String, val flags: String?) : FluoriteValu
         if (flagData.multiline) options += RegexOption.MULTILINE
         if (flagData.ignoreCase) options += RegexOption.IGNORE_CASE
         pattern.toRegex(options)
+    }
+
+    fun withFlag(flag: String, enable: Boolean): FluoriteRegex {
+        flag.forEach {
+            if (it != 'm' && it != 'i' && it != 'g') throw FluoriteException("Invalid flag: $it".toFluoriteString())
+        }
+        val oldFlags = flags ?: ""
+        val newFlags = if (enable) {
+            buildString {
+                append(oldFlags)
+                flag.forEach { if (it !in this) append(it) }
+            }
+        } else {
+            oldFlags.filter { it !in flag }
+        }
+        if (newFlags == oldFlags) return this
+        return FluoriteRegex(pattern, newFlags.ifEmpty { null })
     }
 
     private fun matchImpl(string: String): FluoriteValue {

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteRegex.kt
@@ -48,8 +48,10 @@ data class FluoriteRegex(val pattern: String, val flags: String?) : FluoriteValu
                     },
                     "withoutFlag" to FluoriteFunction.immediate { arguments ->
                         val regex = arguments[0] as FluoriteRegex
-                        val flag = arguments[1].toFluoriteString(null).value
-                        regex.withFlag(flag, false)
+                        when (arguments.size) {
+                            2 -> regex.withFlag(arguments[1].toFluoriteString(null).value, false)
+                            else -> throw FluoriteException("Usage: REGEX::withoutFlag(flag: STRING): REGEX".toFluoriteString())
+                        }
                     },
                     OperatorMethod.PLUS.methodName to FluoriteFunction.immediate { arguments ->
                         val regex = arguments[0] as FluoriteRegex

--- a/src/commonTest/kotlin/RegexTest.kt
+++ b/src/commonTest/kotlin/RegexTest.kt
@@ -2,6 +2,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mirrg.xarpite.compilers.objects.FluoriteNull
 import mirrg.xarpite.compilers.objects.FluoriteRegex
+import mirrg.xarpite.operations.FluoriteException
 import mirrg.xarpite.test.array
 import mirrg.xarpite.test.boolean
 import mirrg.xarpite.test.eval
@@ -10,7 +11,9 @@ import mirrg.xarpite.test.stream
 import mirrg.xarpite.test.string
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RegexTest {
@@ -97,6 +100,41 @@ class RegexTest {
         assertEquals("ABC", eval(""" /ABC/gim.pattern """).string) // patternの取得
         assertEquals("gim", eval(""" /ABC/gim.flags """).string) // flagsの取得
         assertEquals(FluoriteNull, eval(""" /ABC/.flags """)) // nullのflagsの取得
+    }
+
+    @Test
+    fun withFlag() = runTest {
+        assertEquals(FluoriteRegex("abc", "g"), eval(""" /abc/::withFlag("g"; TRUE) """)) // 基本形でフラグを付与
+        assertEquals(FluoriteRegex("abc", null), eval(""" /abc/g::withFlag("g"; FALSE) """)) // 基本形でフラグを除去
+
+        assertEquals(FluoriteRegex("abc", "g"), eval(""" /abc/::withFlag("g") """)) // 第2引数省略で付与
+        assertEquals(FluoriteRegex("abc", null), eval(""" /abc/g::withoutFlag("g") """)) // withoutFlagで除去
+        assertEquals(FluoriteRegex("abc", "g"), eval(""" /abc/ + "g" """)) // +演算子で付与
+        assertEquals(FluoriteRegex("abc", null), eval(""" /abc/g - "g" """)) // -演算子で除去
+
+        assertEquals(FluoriteRegex("abc", "gi"), eval(""" /abc/gi::withFlag("g") """)) // 既にあるフラグの付与は結果を変えない
+        assertEquals(FluoriteRegex("abc", "gi"), eval(""" /abc/gi::withoutFlag("m") """)) // 無いフラグの除去は結果を変えない
+
+        assertEquals(FluoriteRegex("abc", "ig"), eval(""" /abc/i::withFlag("g") """)) // 正規化せず常に末尾に追記
+
+        assertEquals(FluoriteRegex("abc", "gi"), eval(""" /abc/::withFlag("gi") """)) // 複数文字をまとめて付与
+        assertEquals(FluoriteRegex("abc", "gi"), eval(""" /abc/g::withFlag("gi") """)) // 既存分は飛ばして残りのみ末尾に追記
+        assertEquals(FluoriteRegex("abc", null), eval(""" /abc/gm::withoutFlag("gm") """)) // 複数文字をまとめて除去
+        assertEquals(FluoriteRegex("abc", "g"), eval(""" /abc/ + "gi" - "i" """)) // 演算子でも複数文字が使える
+
+        assertEquals(FluoriteNull, eval(""" /abc/g::withoutFlag("g").flags """)) // 全フラグを除去するとflagsはNULL
+
+        assertFailsWith<FluoriteException> { eval(""" /abc/::withFlag("x") """) } // 不正フラグはエラー
+        assertFailsWith<FluoriteException> { eval(""" /abc/::withoutFlag("x") """) } // 除去でも不正フラグはエラー
+        assertFailsWith<FluoriteException> { eval(""" /abc/ + "x" """) } // 演算子でも不正フラグはエラー
+    }
+
+    @Test
+    fun withFlagIdentity() = runTest {
+        val withG = FluoriteRegex("abc", "g")
+        assertSame(withG, withG.withFlag("g", true)) // 既に満たしていれば元のインスタンスをそのまま返す
+        val withoutG = FluoriteRegex("abc", null)
+        assertSame(withoutG, withoutG.withFlag("g", false)) // 既に満たしていれば元のインスタンスをそのまま返す
     }
 
 }

--- a/src/commonTest/kotlin/RegexTest.kt
+++ b/src/commonTest/kotlin/RegexTest.kt
@@ -128,6 +128,11 @@ class RegexTest {
         assertFailsWith<FluoriteException> { eval(""" /abc/::withoutFlag("x") """) } // 除去でも不正フラグはエラー
         assertFailsWith<FluoriteException> { eval(""" /abc/ + "x" """) } // +演算子でも不正フラグはエラー
         assertFailsWith<FluoriteException> { eval(""" /abc/g - "x" """) } // -演算子でも不正フラグはエラー
+
+        assertFailsWith<FluoriteException> { eval(""" /abc/::withFlag() """) } // withFlagは引数不足でエラー
+        assertFailsWith<FluoriteException> { eval(""" /abc/::withFlag("g"; TRUE; TRUE) """) } // withFlagは引数過多でエラー
+        assertFailsWith<FluoriteException> { eval(""" /abc/::withoutFlag() """) } // withoutFlagは引数不足でエラー
+        assertFailsWith<FluoriteException> { eval(""" /abc/::withoutFlag("g"; TRUE) """) } // withoutFlagは引数過多でエラー
     }
 
     @Test

--- a/src/commonTest/kotlin/RegexTest.kt
+++ b/src/commonTest/kotlin/RegexTest.kt
@@ -126,7 +126,8 @@ class RegexTest {
 
         assertFailsWith<FluoriteException> { eval(""" /abc/::withFlag("x") """) } // 不正フラグはエラー
         assertFailsWith<FluoriteException> { eval(""" /abc/::withoutFlag("x") """) } // 除去でも不正フラグはエラー
-        assertFailsWith<FluoriteException> { eval(""" /abc/ + "x" """) } // 演算子でも不正フラグはエラー
+        assertFailsWith<FluoriteException> { eval(""" /abc/ + "x" """) } // +演算子でも不正フラグはエラー
+        assertFailsWith<FluoriteException> { eval(""" /abc/g - "x" """) } // -演算子でも不正フラグはエラー
     }
 
     @Test


### PR DESCRIPTION
## 概要

正規表現オブジェクトから、フラグを付与または除去した新しい正規表現オブジェクトを得る API を追加するのだ。

基本形を `REGEX::withFlag(flag; enable)` に据えて、`withoutFlag` および `+` / `-` 演算子をその略記として揃えるのだ。

議論の文脈は https://github.com/MirrgieRiana/xarpite/issues/547#issuecomment-4880748117 を参照するのだ。

Closes #547

## 仕様

`REGEX::withFlag(flag: STRING[; enable: BOOLEAN]): REGEX` を基本形とし、以下をその略記とするのだ。

| 記法 | 基本形 |
| --- | --- |
| `regex::withFlag(flag)` | `regex::withFlag(flag; TRUE)` |
| `regex::withoutFlag(flag)` | `regex::withFlag(flag; FALSE)` |
| `regex + flag` | `regex::withFlag(flag; TRUE)` |
| `regex - flag` | `regex::withFlag(flag; FALSE)` |

- 操作は冪等とし、既にあるフラグの付与や、無いフラグの除去は結果を変えないのだ。
- 更に、結果が元の正規表現と等しくなる場合は、元のインスタンスをそのまま返すのだ（この挙動はドキュメント化しないのだ）。
- `flag` には `gi` のように複数のフラグ文字をまとめて記述できるのだ。
- 付与されるフラグは正規化せず、常に既存のフラグ列の末尾に追記するのだ。
- すべてのフラグが除去された場合、`flags` は `NULL` になるのだ。
- `flag` に正規表現のフラグとして不正な文字が含まれる場合、エラーになるのだ。

既存の挙動を変えない純粋な追加であり、API バージョンによるオプトインは不要なのだ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
