### PR TITLE
ファイル列挙系の関数をゼロ引数で PWD 基準に呼び出せるようにするのだ

### DIFF
--- a/changelog.d/file-enum-pwd-default.md
+++ b/changelog.d/file-enum-pwd-default.md
@@ -1,0 +1,1 @@
+Added support for calling the `FILES`, `FILE_NAMES`, `TREE`, and `FILE_TREE` functions with no arguments to enumerate `PWD`.

--- a/changelog.d/file-enum-pwd-default.md
+++ b/changelog.d/file-enum-pwd-default.md
@@ -1,1 +1,1 @@
-Added support for calling the `FILES`, `FILE_NAMES`, `TREE`, and `FILE_TREE` functions with no arguments to enumerate `PWD`.
+Added support for calling the `FILES`, `FILE_NAMES`, `TREE`, and `FILE_TREE` functions with no arguments to enumerate the contents of `PWD`.

--- a/pages/docs/en/cli.md
+++ b/pages/docs/en/cli.md
@@ -746,9 +746,11 @@ $ xa -q '65, 66, 67, 10 >> ERRB' > /dev/null
 
 ### `FILES` / `FILE_NAMES`: Get List of Files in Directory
 
-`FILES(dir: STRING): STREAM<STRING>`
+`FILES([dir: STRING]): STREAM<STRING>`
 
 Gets a stream of filenames directly under the directory specified by `dir`.
+
+If `dir` is omitted, `PWD` is used.
 
 `FILE_NAMES` is an alias for `FILES` and has the same behavior.
 
@@ -774,9 +776,11 @@ $ {
 
 ### `TREE`: Get All Files and Directories Under Directory
 
-`TREE(dir: STRING): STREAM<STRING>`
+`TREE([dir: STRING]): STREAM<STRING>`
 
 Returns a stream that recursively searches for all directories and files under `dir`.
+
+If `dir` is omitted, `PWD` is used.
 
 Returned path strings include `dir` at the beginning.
 
@@ -806,9 +810,11 @@ $ {
 
 ### `FILE_TREE`: Get All Files Under Directory
 
-`FILE_TREE(dir: STRING): STREAM<STRING>`
+`FILE_TREE([dir: STRING]): STREAM<STRING>`
 
 Returns a stream that recursively searches for all files under `dir`.
+
+If `dir` is omitted, `PWD` is used.
 
 Directory paths are not reported.
 

--- a/pages/docs/ja/cli.md
+++ b/pages/docs/ja/cli.md
@@ -746,9 +746,11 @@ $ xa -q '65, 66, 67, 10 >> ERRB' > /dev/null
 
 ### `FILES` / `FILE_NAMES`: ディレクトリ内のファイルの一覧を取得
 
-`FILES(dir: STRING): STREAM<STRING>`
+`FILES([dir: STRING]): STREAM<STRING>`
 
 `dir`で指定されたディレクトリ直下のファイル名のストリームを取得します。
+
+`dir`を省略した場合は`PWD`が使用されます。
 
 `FILE_NAMES`は`FILES`の別名であり、同一の動作を持ちます。
 
@@ -774,9 +776,11 @@ $ {
 
 ### `TREE`: ディレクトリ配下のすべてのファイルとディレクトリを取得
 
-`TREE(dir: STRING): STREAM<STRING>`
+`TREE([dir: STRING]): STREAM<STRING>`
 
 `dir`の配下にあるすべてのディレクトリとファイルのパスを再帰的に検索するストリームを返します。
+
+`dir`を省略した場合は`PWD`が使用されます。
 
 返されるパス文字列の先頭には`dir`が含まれます。
 
@@ -806,9 +810,11 @@ $ {
 
 ### `FILE_TREE`: ディレクトリ配下のすべてのファイルを取得
 
-`FILE_TREE(dir: STRING): STREAM<STRING>`
+`FILE_TREE([dir: STRING]): STREAM<STRING>`
 
 `dir`の配下にあるすべてのファイルのパスを再帰的に検索するストリームを返します。
+
+`dir`を省略した場合は`PWD`が使用されます。
 
 ディレクトリのパスは報告されません。
 

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliMounts.kt
@@ -189,8 +189,11 @@ fun createCliMounts(args: List<String>): List<Map<String, Mount>> {
         *run {
             fun create(name: String, fullPath: Boolean): FluoriteFunction {
                 return FluoriteFunction.immediate { arguments ->
-                    if (arguments.size != 1) usage("$name(dir: STRING): STREAM<STRING>")
-                    val dir = arguments[0].toFluoriteString(null).value
+                    val dir = when (arguments.size) {
+                        0 -> context.io.getPwd()
+                        1 -> arguments[0].toFluoriteString(null).value
+                        else -> usage("$name([dir: STRING]): STREAM<STRING>")
+                    }
                     val fileSystem = getFileSystem().getOrThrow()
                     fileSystem.list(dir.toPath()).map { (if (fullPath) it.toString() else it.name).toFluoriteString() }.toFluoriteStream()
                 }
@@ -203,8 +206,11 @@ fun createCliMounts(args: List<String>): List<Map<String, Mount>> {
         *run {
             fun create(name: String, includeDirectories: Boolean): FluoriteFunction {
                 return FluoriteFunction.immediate { arguments ->
-                    if (arguments.size != 1) usage("$name(dir: STRING): STREAM<STRING>")
-                    val dirPath = arguments[0].toFluoriteString(null).value.toPath()
+                    val dirPath = when (arguments.size) {
+                        0 -> context.io.getPwd()
+                        1 -> arguments[0].toFluoriteString(null).value
+                        else -> usage("$name([dir: STRING]): STREAM<STRING>")
+                    }.toPath()
                     val fileSystem = getFileSystem().getOrThrow()
 
                     FluoriteStream {

--- a/src/commonTest/kotlin/CliTest.kt
+++ b/src/commonTest/kotlin/CliTest.kt
@@ -510,6 +510,13 @@ class CliTest {
         val fileNamesResultV5 = cliEval(context, "FILE_NAMES(ARGS.0)", dir.toString(), apiVersion = 5).stream()
         assertEquals("apple.txt,banana,zebra.txt", fileNamesResultV5)
 
+        // ゼロ引数で呼び出すと PWD を基準にする
+        val pwdContext = TestIoContext(env = mapOf("XARPITE_PWD" to dir.toString()))
+        val filesResultPwd = cliEval(pwdContext, "FILES()", apiVersion = 5).stream()
+        assertEquals("$dir/apple.txt,$dir/banana,$dir/zebra.txt", filesResultPwd)
+        val fileNamesResultPwd = cliEval(pwdContext, "FILE_NAMES()").stream()
+        assertEquals("apple.txt,banana,zebra.txt", fileNamesResultPwd)
+
         // クリーンアップ
         fileSystem.deleteRecursively(dir)
     }
@@ -535,6 +542,11 @@ class CliTest {
         val expected = "${dir}/dir1,${dir}/dir1/dir2,${dir}/dir1/dir2/file2.txt,${dir}/dir1/file1.txt,${dir}/empty-dir"
         assertEquals(expected, result)
 
+        // ゼロ引数で呼び出すと PWD を基準にする
+        val pwdContext = TestIoContext(env = mapOf("XARPITE_PWD" to dir.toString()))
+        val resultPwd = cliEval(pwdContext, "TREE()").stream()
+        assertEquals(expected, resultPwd)
+
         // クリーンアップ
         fileSystem.deleteRecursively(dir)
     }
@@ -559,6 +571,11 @@ class CliTest {
         // パスには dir が含まれる
         val expected = "${dir}/dir1/dir2/file2.txt,${dir}/dir1/file1.txt"
         assertEquals(expected, result)
+
+        // ゼロ引数で呼び出すと PWD を基準にする
+        val pwdContext = TestIoContext(env = mapOf("XARPITE_PWD" to dir.toString()))
+        val resultPwd = cliEval(pwdContext, "FILE_TREE()").stream()
+        assertEquals(expected, resultPwd)
 
         // クリーンアップ
         fileSystem.deleteRecursively(dir)


### PR DESCRIPTION
## 概要

ファイル列挙系の関数を、引数なしで呼び出したときに `PWD` を対象ディレクトリとして扱うようにするのだ。

対象は以下の4つの関数なのだ。

- `FILES` / `FILE_NAMES` （ディレクトリ直下の一覧）
- `TREE` / `FILE_TREE` （配下を再帰的に列挙）

これまでこれらは引数ちょうど1個を要求していたのだ。ゼロ引数の場合を追加する非破壊的な変更であり、マイナーアップデート扱いなのだ。

## 変更内容

- `CliMounts.kt`: 4つの関数の引数処理を「0個→`PWD`、1個→指定 `dir`、それ以外→usage エラー」に変更するのだ。
- `CliTest.kt`: `files` / `tree` / `fileTree` の各テストに、`XARPITE_PWD` 経由でゼロ引数呼び出しを検証するケースを追加するのだ。
- `pages/docs/ja/cli.md` / `pages/docs/en/cli.md`: シグネチャを `([dir: STRING])` に更新し、`dir` を省略した場合は `PWD` が使用される旨を追記するのだ。
- `changelog.d/`: 更新履歴の断片を追加するのだ。

## 発端

Issue #678 のタイトルの案「`TREE` や `FILES` とかはゼロ引数で呼び出したら `PWD` を基準にしたい」を実装したものなのだ。

Closes #678

<sub>この PR は https://github.com/MirrgieRiana/xarpite/issues/678#issuecomment-4884882241 の依頼を起点に作成されたのだ。</sub>


🌱 <!-- !fairy[https://github.com/MirrgieRiana/xarpite/issues/681#issuecomment-4888884668] -->
