### PR TITLE
ファイルの存在を確認する `EXISTS` 関数を追加するのだ〜

### DIFF
--- a/changelog.d/add-exists-function.md
+++ b/changelog.d/add-exists-function.md
@@ -1,0 +1,1 @@
+Added `EXISTS` function that returns whether a file exists at the given path.

--- a/changelog.d/add-exists-function.md
+++ b/changelog.d/add-exists-function.md
@@ -1,1 +1,1 @@
-Added `EXISTS` function that returns whether a file exists at the given path.
+Added `EXISTS` function that returns whether a file or directory exists at the given path.

--- a/pages/docs/en/cli.md
+++ b/pages/docs/en/cli.md
@@ -744,6 +744,25 @@ $ xa -q '65, 66, 67, 10 >> ERRB' > /dev/null
 # ABC
 ```
 
+### `EXISTS`: Check Whether a File Exists
+
+`EXISTS(file: STRING): BOOLEAN`
+
+Returns `TRUE` if a file exists at the path specified by `file`, and `FALSE` otherwise.
+
+It also returns `TRUE` when the path points to a directory.
+
+```shell
+$ {
+  touch tmp.txt
+  xa 'EXISTS("tmp.txt")'
+  xa 'EXISTS("no_such_file.txt")'
+  rm tmp.txt
+}
+# TRUE
+# FALSE
+```
+
 ### `FILES` / `FILE_NAMES`: Get List of Files in Directory
 
 `FILES(dir: STRING): STREAM<STRING>`

--- a/pages/docs/ja/cli.md
+++ b/pages/docs/ja/cli.md
@@ -744,6 +744,25 @@ $ xa -q '65, 66, 67, 10 >> ERRB' > /dev/null
 # ABC
 ```
 
+### `EXISTS`: ファイルの存在の確認
+
+`EXISTS(file: STRING): BOOLEAN`
+
+`file`で指定されたパスにファイルが存在する場合は`TRUE`を、存在しない場合は`FALSE`を返します。
+
+パスがディレクトリを指す場合も`TRUE`を返します。
+
+```shell
+$ {
+  touch tmp.txt
+  xa 'EXISTS("tmp.txt")'
+  xa 'EXISTS("no_such_file.txt")'
+  rm tmp.txt
+}
+# TRUE
+# FALSE
+```
+
 ### `FILES` / `FILE_NAMES`: ディレクトリ内のファイルの一覧を取得
 
 `FILES(dir: STRING): STREAM<STRING>`

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliMounts.kt
@@ -18,6 +18,7 @@ import mirrg.xarpite.compilers.objects.consumeToMutableList
 import mirrg.xarpite.compilers.objects.iterateBlobs
 import mirrg.xarpite.compilers.objects.toFlow
 import mirrg.xarpite.compilers.objects.toFluoriteArray
+import mirrg.xarpite.compilers.objects.toFluoriteBoolean
 import mirrg.xarpite.compilers.objects.toFluoriteNumber
 import mirrg.xarpite.compilers.objects.toFluoriteStream
 import mirrg.xarpite.compilers.objects.toFluoriteString
@@ -185,6 +186,12 @@ fun createCliMounts(args: List<String>): List<Map<String, Mount>> {
                 }
             }
             FluoriteNull
+        },
+        "EXISTS" define FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("EXISTS(file: STRING): BOOLEAN")
+            val file = arguments[0].toFluoriteString(null).value
+            val fileSystem = getFileSystem().getOrThrow()
+            fileSystem.exists(file.toPath()).toFluoriteBoolean()
         },
         *run {
             fun create(name: String, fullPath: Boolean): FluoriteFunction {

--- a/src/commonTest/kotlin/CliTest.kt
+++ b/src/commonTest/kotlin/CliTest.kt
@@ -481,6 +481,30 @@ class CliTest {
     }
 
     @Test
+    fun exists() = runTest {
+        val context = TestIoContext()
+        if (getFileSystem().isFailure) return@runTest
+        val fileSystem = getFileSystem().getOrThrow()
+        fileSystem.createDirectories(baseDir)
+        val dir = baseDir.resolve("exists.test_dir.tmp")
+
+        fileSystem.deleteRecursively(dir, mustExist = false)
+
+        fileSystem.createDirectory(dir)
+        val file = dir.resolve("file.txt")
+        fileSystem.write(file) { writeUtf8("") }
+
+        // 存在するファイルには TRUE を返す
+        assertEquals("TRUE", cliEval(context, "EXISTS(ARGS.0)", file.toString()).toFluoriteString(null).value)
+        // 存在するディレクトリにも TRUE を返す
+        assertEquals("TRUE", cliEval(context, "EXISTS(ARGS.0)", dir.toString()).toFluoriteString(null).value)
+        // 存在しないパスには FALSE を返す
+        assertEquals("FALSE", cliEval(context, "EXISTS(ARGS.0)", dir.resolve("missing.txt").toString()).toFluoriteString(null).value)
+
+        fileSystem.deleteRecursively(dir)
+    }
+
+    @Test
     fun files() = runTest {
         val context = TestIoContext()
         if (getFileSystem().isFailure) return@runTest


### PR DESCRIPTION
指定したパスにファイルが存在するかを返す組み込み関数 `EXISTS` を追加するのだ。

これまで Xarpite には、`READ` で読み込む前や `WRITE` で書き込む前に、そのファイルが既に存在するかを確かめる手段が無かったのだ。`EXISTS` は、内部のファイルシステムの存在判定をそのまま呼ぶだけの、シンプルなラッパー関数なのだ。

## 変更するもの

- `EXISTS` 関数: `file` で指定されたパスにファイルが存在すれば `TRUE` を、存在しなければ `FALSE` を返す。パスがディレクトリを指す場合も `TRUE` を返す。

## 仕様

`EXISTS(file: STRING): BOOLEAN`

| 式                              | 戻り値     |
|--------------------------------|---------|
| 存在するファイルのパス             | `TRUE`  |
| 存在するディレクトリのパス         | `TRUE`  |
| 存在しないパス                   | `FALSE` |

## 文脈

このPRは Issue #672 に基づくのだ。

Closes #672
