### PR TITLE
`PARENT` のシノニム `TYPE` 関数を追加するのだ

### DIFF
--- a/changelog.d/add-type-function.md
+++ b/changelog.d/add-type-function.md
@@ -1,0 +1,1 @@
+Added `TYPE` as a synonym for `PARENT` to get the parent object of a value.

--- a/pages/docs/en/object.md
+++ b/pages/docs/en/object.md
@@ -263,9 +263,9 @@ $ xa '
 # {b:banana}
 ```
 
-# Built-in Function `PARENT`
+# Built-in Function `PARENT` / `TYPE`
 
-## `PARENT`: Getting the Parent Object
+## `PARENT` / `TYPE`: Getting the Parent Object
 
 `PARENT(value: VALUE): OBJECT | NULL`
 
@@ -280,6 +280,8 @@ For a value at the root of the inheritance chain, it returns NULL.
 For any other value, it returns the corresponding class constant.
 
 If `value` is a stream, it is not applied element-wise but returns `STREAM`, the parent object of the stream itself.
+
+`TYPE` is an alias of `PARENT` and has the same behavior.
 
 ```shell
 $ xa '

--- a/pages/docs/ja/object.md
+++ b/pages/docs/ja/object.md
@@ -263,9 +263,9 @@ $ xa '
 # {b:banana}
 ```
 
-# 組み込み関数`PARENT`
+# 組み込み関数`PARENT` / `TYPE`
 
-## `PARENT`: 親オブジェクトの取得
+## `PARENT` / `TYPE`: 親オブジェクトの取得
 
 `PARENT(value: VALUE): OBJECT | NULL`
 
@@ -280,6 +280,8 @@ $ xa '
 それ以外の値に対しては、対応するクラス定数を返します。
 
 `value`がストリームの場合も、要素ごとではなく、ストリームそのものの親オブジェクトである`STREAM`を返します。
+
+`TYPE`は`PARENT`の別名であり、同一の動作を持ちます。
 
 ```shell
 $ xa '

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/ObjectMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/ObjectMounts.kt
@@ -8,10 +8,14 @@ import mirrg.xarpite.define
 
 context(context: RuntimeContext)
 fun createObjectMounts(): List<Map<String, Mount>> {
-    return mapOf(
-        "PARENT" define FluoriteFunction.immediate { arguments ->
-            if (arguments.size != 1) usage("PARENT(value: VALUE): OBJECT | NULL")
+    fun createParent(name: String): FluoriteFunction {
+        return FluoriteFunction.immediate { arguments ->
+            if (arguments.size != 1) usage("$name(value: VALUE): OBJECT | NULL")
             arguments[0].parent ?: FluoriteNull
-        },
+        }
+    }
+    return mapOf(
+        "PARENT" define createParent("PARENT"),
+        "TYPE" define createParent("TYPE"),
     ).let { listOf(it) }
 }

--- a/src/commonTest/kotlin/ObjectTest.kt
+++ b/src/commonTest/kotlin/ObjectTest.kt
@@ -62,6 +62,7 @@ class ObjectTest {
         // TYPE は PARENT のシノニム
         assertEquals(true, eval("TYPE(1) == INT").boolean) // TYPE でも値の親オブジェクトを得る
         assertEquals(true, eval("TYPE(VALUE) == NULL").boolean) // TYPE でも親を持たない値は NULL を返す
+        assertEquals(true, eval("TYPE(1, 2, 3) == STREAM").boolean) // TYPE でもストリームを渡すとストリーム自身の親 STREAM を返す
     }
 
     @Test

--- a/src/commonTest/kotlin/ObjectTest.kt
+++ b/src/commonTest/kotlin/ObjectTest.kt
@@ -58,6 +58,10 @@ class ObjectTest {
         assertEquals(true, eval("A := {}; a := A{}; PARENT(a) == A").boolean) // インスタンスの親はそのクラス
         assertEquals(true, eval("Animal := {}; Human := Animal{}; PARENT(Human) == Animal").boolean) // クラスの親は親クラス
         assertEquals(true, eval("PARENT(1, 2, 3) == STREAM").boolean) // ストリームを渡すとストリーム自身の親 STREAM を返す
+
+        // TYPE は PARENT のシノニム
+        assertEquals(true, eval("TYPE(1) == INT").boolean) // TYPE でも値の親オブジェクトを得る
+        assertEquals(true, eval("TYPE(VALUE) == NULL").boolean) // TYPE でも親を持たない値は NULL を返す
     }
 
     @Test


### PR DESCRIPTION
## 概要

値の親オブジェクトを返す組み込み関数 `PARENT` のシノニムとして、`TYPE` 関数を追加するのだ。

`TYPE` は `PARENT` と完全に同一の動作を持つ別名で、`TYPE(1) == INT` のように、値の親オブジェクトを取得できるのだ。

議論の文脈は https://github.com/MirrgieRiana/xarpite/issues/668#issuecomment-4880309247 を参照するのだ。

Close #668

## 仕様

`TYPE(value: VALUE): OBJECT | NULL` は `PARENT` と同じく、`value` の親オブジェクト、もしくは `NULL` を返すのだ。既存の `SHELL_ESCAPE` / `BASH_ESCAPE` と同様に、同一の実装を2つの名前でマウントする形で追加したのだ。usage メッセージには呼び出しに使われた名前がそのまま反映されるのだ。

これは純粋な機能追加であり、破壊的変更を含まないため、API バージョンのオプトインは不要なのだ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)