### PR TITLE
`::IS` 拡張関数を追加するのだ

### DIFF
--- a/changelog.d/is-extension-function.md
+++ b/changelog.d/is-extension-function.md
@@ -1,0 +1,1 @@
+Added `::IS` extension function as sugar for the `?=` instanceOf operator.

--- a/pages/docs/en/comparison.md
+++ b/pages/docs/en/comparison.md
@@ -291,3 +291,16 @@ The `::CONTAINS` extension function is syntactic sugar for calling the containme
 $ xa ' "abcde"::CONTAINS("bcd") '
 # TRUE
 ```
+
+## `::IS`: Extension Function for instanceOf
+
+`VALUE::IS(class: VALUE): BOOLEAN`
+
+The `::IS` extension function is syntactic sugar for calling the instanceOf operator `?=` in extension function form.
+
+`value::IS(class)` is equivalent to `value ?= class`.
+
+```shell
+$ xa ' 1::IS(INT) '
+# TRUE
+```

--- a/pages/docs/ja/comparison.md
+++ b/pages/docs/ja/comparison.md
@@ -291,3 +291,16 @@ $ xa '
 $ xa ' "abcde"::CONTAINS("bcd") '
 # TRUE
 ```
+
+## `::IS`: instanceOf判定を行う拡張関数
+
+`VALUE::IS(class: VALUE): BOOLEAN`
+
+`::IS`拡張関数はinstanceOf演算子`?=`を拡張関数の形式で呼び出すためのシンタックスシュガーです。
+
+`value::IS(class)`は`value ?= class`と等価です。
+
+```shell
+$ xa ' 1::IS(INT) '
+# TRUE
+```

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/LangMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/LangMounts.kt
@@ -20,8 +20,10 @@ import mirrg.xarpite.compilers.objects.colon
 import mirrg.xarpite.compilers.objects.consume
 import mirrg.xarpite.compilers.objects.contains
 import mirrg.xarpite.compilers.objects.fluoriteArrayOf
+import mirrg.xarpite.compilers.objects.instanceOf
 import mirrg.xarpite.compilers.objects.invoke
 import mirrg.xarpite.compilers.objects.invokeImmediate
+import mirrg.xarpite.compilers.objects.toFluoriteBoolean
 import mirrg.xarpite.compilers.objects.toFluoriteString
 import mirrg.xarpite.copy
 import mirrg.xarpite.define
@@ -185,6 +187,12 @@ fun createLangMounts(): List<Map<String, Mount>> {
             FluoriteValue.fluoriteClass colon FluoriteFunction.immediate { arguments ->
                 if (arguments.size != 2) usage("VALUE::CONTAINS(content: VALUE): BOOLEAN")
                 arguments[0].contains(null, arguments[1])
+            },
+        ),
+        "::IS" define fluoriteArrayOf(
+            FluoriteValue.fluoriteClass colon FluoriteFunction.immediate { arguments ->
+                if (arguments.size != 2) usage("VALUE::IS(class: VALUE): BOOLEAN")
+                arguments[0].instanceOf(arguments[1]).toFluoriteBoolean()
             },
         ),
         "LAZY" define FluoriteFunction.immediate { arguments ->

--- a/src/commonTest/kotlin/XarpiteTest.kt
+++ b/src/commonTest/kotlin/XarpiteTest.kt
@@ -939,6 +939,16 @@ class XarpiteTest {
         assertEquals(false, eval("(1, 2) ?= ARRAY").boolean)
         assertEquals(false, eval("1.2 ?= INT").boolean)
         assertEquals(false, eval("1 ?= DOUBLE").boolean)
+
+        // ::IS拡張関数でinstanceOf判定ができる
+        assertEquals(true, eval("1::IS(INT)").boolean)
+        assertEquals(true, eval("'a'::IS(STRING)").boolean)
+        assertEquals(false, eval("1::IS(STRING)").boolean)
+        assertEquals(false, eval("'10'::IS(INT)").boolean)
+
+        // ::IS拡張関数はユーザー定義の継承チェーンでも動作する
+        assertEquals(true, eval("Animal := {}; Human := Animal {}; Human{}::IS(Animal)").boolean)
+        assertEquals(false, eval("Animal := {}; Human := Animal {}; Animal{}::IS(Human)").boolean)
     }
 
     @Test


### PR DESCRIPTION
## 概要

instanceOf 演算子 `?=` を拡張関数の形式で呼び出すための `::IS` 拡張関数を追加するのだ。

これは含有演算子 `@` の関数版である `::CONTAINS` 拡張関数と対になる、`?=` 演算子の関数版なのだ。

議論の文脈は https://github.com/MirrgieRiana/xarpite/issues/649 を参照するのだ。

## 仕様

`::IS` 拡張関数は、instanceOf 演算子 `?=` を拡張関数の形式で呼び出すためのシンタックスシュガーなのだ。

`VALUE::IS(class: VALUE): BOOLEAN`

`value::IS(class)` は `value ?= class` と等価なのだ。

```shell
$ xa ' 1::IS(INT) '
# TRUE
```

## 実装の対応

先例である `::CONTAINS`（`container::CONTAINS(content)` = `content @ container`）に倣った実装なのだ。`::CONTAINS` は動詞「container が content を含む」の自然な読みに合わせて受け手を右辺に取っていたのだ。`::IS` は「value is class」の自然な読みに合わせ、受け手を左辺（`?=` の左オペランド）に取っているのだ。

## 変更点

- `LangMounts.kt` に `::IS` を登録（`::CONTAINS` の隣）
- `XarpiteTest.kt` に `::IS` のテストを追加
- `pages/docs/{ja,en}/comparison.md` の「比較系関数」節に `::IS` を追記
- CHANGELOG 断片を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
