### PR TITLE
`XARPITE_API_VERSION` 環境変数で API バージョンを指定できるようにするのだ

### DIFF
--- a/changelog.d/xarpite-api-version-env.md
+++ b/changelog.d/xarpite-api-version-env.md
@@ -1,0 +1,1 @@
+Added the `XARPITE_API_VERSION` environment variable to set the API version when the `-A` option is not specified.

--- a/pages/docs/en/cli.md
+++ b/pages/docs/en/cli.md
@@ -282,11 +282,11 @@ $ XARPITE_API_VERSION=4 xa 'API_VERSION'
 
 ---
 
-Specifying the API version via the `-A` option takes precedence over specification via the environment variable.
+The API version is determined based on the following priority:
 
----
-
-When neither the `-A` option nor the `XARPITE_API_VERSION` environment variable is specified, the API version becomes the same value as Xarpite's own major version.
+1. The `-A` option
+2. The `XARPITE_API_VERSION` environment variable
+3. Xarpite's own major version
 
 ---
 

--- a/pages/docs/en/cli.md
+++ b/pages/docs/en/cli.md
@@ -271,9 +271,22 @@ $ xa -A 4 'API_VERSION'
 # 4
 ```
 
+### `XARPITE_API_VERSION`: Environment Variable to Specify the API Version
+
+The `XARPITE_API_VERSION` environment variable specifies the API version of the runtime.
+
+```shell
+$ XARPITE_API_VERSION=4 xa 'API_VERSION'
+# 4
+```
+
 ---
 
-When the `-A` option is not specified, the API version becomes the same value as Xarpite's own major version.
+Specifying the API version via the `-A` option takes precedence over specification via the environment variable.
+
+---
+
+When neither the `-A` option nor the `XARPITE_API_VERSION` environment variable is specified, the API version becomes the same value as Xarpite's own major version.
 
 ---
 

--- a/pages/docs/ja/cli.md
+++ b/pages/docs/ja/cli.md
@@ -271,9 +271,22 @@ $ xa -A 4 'API_VERSION'
 # 4
 ```
 
+### `XARPITE_API_VERSION`: APIバージョンを指定する環境変数
+
+`XARPITE_API_VERSION`環境変数はランタイムのAPIバージョンを指定します。
+
+```shell
+$ XARPITE_API_VERSION=4 xa 'API_VERSION'
+# 4
+```
+
 ---
 
-`-A`オプションを指定しない場合、APIバージョンはXarpite自身のメジャーバージョンと同じ値になります。
+`-A`オプションによるAPIバージョンの指定は環境変数による指定よりも優先されます。
+
+---
+
+`-A`オプションと`XARPITE_API_VERSION`環境変数のいずれも指定されていない場合、APIバージョンはXarpite自身のメジャーバージョンと同じ値になります。
 
 ---
 

--- a/pages/docs/ja/cli.md
+++ b/pages/docs/ja/cli.md
@@ -282,11 +282,11 @@ $ XARPITE_API_VERSION=4 xa 'API_VERSION'
 
 ---
 
-`-A`オプションによるAPIバージョンの指定は環境変数による指定よりも優先されます。
+APIバージョンは以下の優先順位に基づいて決定されます。
 
----
-
-`-A`オプションと`XARPITE_API_VERSION`環境変数のいずれも指定されていない場合、APIバージョンはXarpite自身のメジャーバージョンと同じ値になります。
+1. `-A`オプション
+2. `XARPITE_API_VERSION`環境変数
+3. Xarpite自身のメジャーバージョン
 
 ---
 

--- a/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/cli/CliUtil.kt
@@ -106,6 +106,14 @@ suspend fun parseArguments(args: Iterable<String>, ioContext: IoContext): Option
         }
     }
 
+    // -A が指定されなかった場合、XARPITE_API_VERSION 環境変数があればそれを採用する
+    if (apiVersion == null) {
+        val envApiVersion = ioContext.getEnv()["XARPITE_API_VERSION"]?.notBlankOrNull
+        if (envApiVersion != null) {
+            apiVersion = envApiVersion.toIntOrNull()?.takeIf { it >= 0 } ?: throw ShowUsage
+        }
+    }
+
     // 引数セクションのパース
     run {
 

--- a/src/commonTest/kotlin/CliTest.kt
+++ b/src/commonTest/kotlin/CliTest.kt
@@ -2069,6 +2069,59 @@ class CliTest {
     }
 
     @Test
+    fun apiVersionEnvVarIsUsedWhenOptionAbsent() = runTest {
+        // -A が無指定のとき XARPITE_API_VERSION 環境変数が採用される
+        val context = TestIoContext(env = mapOf("XARPITE_API_VERSION" to "5"))
+        val options = parseArguments(listOf("-e", "1"), context)
+        assertEquals(5, options.apiVersion)
+    }
+
+    @Test
+    fun apiVersionOptionTakesPrecedenceOverEnvVar() = runTest {
+        // -A の指定は XARPITE_API_VERSION 環境変数よりも優先される
+        val context = TestIoContext(env = mapOf("XARPITE_API_VERSION" to "5"))
+        val options = parseArguments(listOf("-A", "4", "-e", "1"), context)
+        assertEquals(4, options.apiVersion)
+    }
+
+    @Test
+    fun apiVersionEnvVarBlankIsIgnored() = runTest {
+        // 空文字の XARPITE_API_VERSION 環境変数は未指定として扱われる
+        val context = TestIoContext(env = mapOf("XARPITE_API_VERSION" to ""))
+        val options = parseArguments(listOf("-e", "1"), context)
+        assertEquals(null, options.apiVersion)
+    }
+
+    @Test
+    fun apiVersionEnvVarRejectsNonInteger() = runTest {
+        // XARPITE_API_VERSION 環境変数に整数でない値を指定するとエラー
+        val context = TestIoContext(env = mapOf("XARPITE_API_VERSION" to "abc"))
+        assertFailsWith<ShowUsage> {
+            parseArguments(listOf("-e", "1"), context)
+        }
+    }
+
+    @Test
+    fun apiVersionEnvVarReflectedInApiVersion() = runTest {
+        // XARPITE_API_VERSION 環境変数の値が API_VERSION に反映される
+        val context = TestIoContext(env = mapOf("XARPITE_VERSION" to "4.120.0", "XARPITE_API_VERSION" to "5"))
+        val options = parseArguments(listOf("-q", "-e", "OUT << API_VERSION"), context)
+        cliEvalImpl(context, options)
+        assertEquals("5\n", context.stdoutBytes.toUtf8String())
+    }
+
+    @Test
+    fun apiVersionEnvVarUnsupportedFailsBeforeExecution() = runTest {
+        // XARPITE_API_VERSION 環境変数に提供していないバージョンを指定すると、スクリプトの実行前にエラーとなる
+        val context = TestIoContext(env = mapOf("XARPITE_VERSION" to "4.120.0", "XARPITE_API_VERSION" to "48"))
+        val options = parseArguments(listOf("-q", "-e", "OUT << \"executed\""), context)
+        cliEvalImpl(context, options)
+        assertEquals("", context.stdoutBytes.toUtf8String())
+        assertTrue(context.stderrBytes.toUtf8String().contains("ERROR:"))
+        assertTrue(context.stderrBytes.toUtf8String().contains("48"))
+    }
+
+    @Test
     fun apiAssertionPassesOnExactMatch() = runTest {
         // API バージョンが厳密一致するとき API は素通りする
         val context = TestIoContext(env = mapOf("XARPITE_VERSION" to "4.120.0"))

--- a/src/commonTest/kotlin/CliTest.kt
+++ b/src/commonTest/kotlin/CliTest.kt
@@ -2093,6 +2093,14 @@ class CliTest {
     }
 
     @Test
+    fun apiVersionEnvVarWhitespaceIsIgnored() = runTest {
+        // 空白のみの XARPITE_API_VERSION 環境変数は未指定として扱われる
+        val context = TestIoContext(env = mapOf("XARPITE_API_VERSION" to "  "))
+        val options = parseArguments(listOf("-e", "1"), context)
+        assertEquals(null, options.apiVersion)
+    }
+
+    @Test
     fun apiVersionEnvVarRejectsNonInteger() = runTest {
         // XARPITE_API_VERSION 環境変数に整数でない値を指定するとエラー
         val context = TestIoContext(env = mapOf("XARPITE_API_VERSION" to "abc"))


### PR DESCRIPTION
`-A` オプションが指定されなかった場合に、APIバージョンを指定する `XARPITE_API_VERSION` 環境変数を追加するのだ。

これまで特定のAPIバージョンで実行するには、毎回 `-A` オプションを付ける必要があったのだ。`XARPITE_API_VERSION` 環境変数を設定しておくことで、`-A` を省略しても、そのAPIバージョンが指定されたものとして扱われるのだ。

## 変更するもの

- `XARPITE_API_VERSION` 環境変数: `-A` オプションが指定されなかった場合、この環境変数の値をAPIバージョンとして採用する。
- `-A` オプションの指定は、この環境変数よりも優先される。
- 空文字（空白のみ）の場合は未指定として扱う。
- `-A` と同様に、整数でない値はエラー、提供していないバージョンはスクリプト実行前のエラーとなる。

## 仕様

`-A` オプションと `XARPITE_API_VERSION` 環境変数のいずれも指定されていない場合、従来通り、APIバージョンはXarpite自身のメジャーバージョンと同じ値になるのだ。

| 状況                                          | 採用されるAPIバージョン |
|---------------------------------------------|----------------|
| `-A` を指定                                   | `-A` の値        |
| `-A` 無指定、`XARPITE_API_VERSION` を指定        | 環境変数の値         |
| `-A` と `XARPITE_API_VERSION` の両方を指定       | `-A` の値        |
| どちらも無指定                                  | メジャーバージョン      |

## 文脈

このPRは Issue #667 に基づくのだ。

Closes #667
