### PR TITLE
`CONTAINS` 関数を追加するのだ

### DIFF
--- a/changelog.d/contains-function.md
+++ b/changelog.d/contains-function.md
@@ -1,0 +1,1 @@
+Added `CONTAINS` function as sugar for the `@` containment operator.

--- a/pages/docs/en/comparison.md
+++ b/pages/docs/en/comparison.md
@@ -287,12 +287,15 @@ $ xa '
 
 The `CONTAINS` function is syntactic sugar for calling the containment operator `@` in function form.
 
-`CONTAINS(container; content)` and `container::CONTAINS(content)` are equivalent to `content @ container`.
+`CONTAINS(container; content)`, `container::CONTAINS(content)`, and the infix call `container CONTAINS content` are equivalent to `content @ container`.
 
 ```shell
 $ xa ' CONTAINS("abcde"; "bcd") '
 # TRUE
 
 $ xa ' "abcde"::CONTAINS("bcd") '
+# TRUE
+
+$ xa ' "abcde" CONTAINS "bcd" '
 # TRUE
 ```

--- a/pages/docs/en/comparison.md
+++ b/pages/docs/en/comparison.md
@@ -279,15 +279,20 @@ $ xa '
 
 # Comparison Functions
 
-## `::CONTAINS`: Extension Function for Containment
+## `CONTAINS`: Function for Containment
+
+`CONTAINS(container: VALUE; content: VALUE): BOOLEAN`
 
 `VALUE::CONTAINS(content: VALUE): BOOLEAN`
 
-The `::CONTAINS` extension function is syntactic sugar for calling the containment operator `@` in extension function form.
+The `CONTAINS` function is syntactic sugar for calling the containment operator `@` in function form.
 
-`container::CONTAINS(content)` is equivalent to `content @ container`.
+`CONTAINS(container; content)` and `container::CONTAINS(content)` are equivalent to `content @ container`.
 
 ```shell
+$ xa ' CONTAINS("abcde"; "bcd") '
+# TRUE
+
 $ xa ' "abcde"::CONTAINS("bcd") '
 # TRUE
 ```

--- a/pages/docs/ja/comparison.md
+++ b/pages/docs/ja/comparison.md
@@ -279,15 +279,20 @@ $ xa '
 
 # 比較系関数
 
-## `::CONTAINS`: 含有判定を行う拡張関数
+## `CONTAINS`: 含有判定を行う関数
+
+`CONTAINS(container: VALUE; content: VALUE): BOOLEAN`
 
 `VALUE::CONTAINS(content: VALUE): BOOLEAN`
 
-`::CONTAINS`拡張関数は含有演算子`@`を拡張関数の形式で呼び出すためのシンタックスシュガーです。
+`CONTAINS`関数は含有演算子`@`を関数の形式で呼び出すためのシンタックスシュガーです。
 
-`container::CONTAINS(content)`は`content @ container`と等価です。
+`CONTAINS(container; content)`および`container::CONTAINS(content)`は`content @ container`と等価です。
 
 ```shell
+$ xa ' CONTAINS("abcde"; "bcd") '
+# TRUE
+
 $ xa ' "abcde"::CONTAINS("bcd") '
 # TRUE
 ```

--- a/pages/docs/ja/comparison.md
+++ b/pages/docs/ja/comparison.md
@@ -287,12 +287,15 @@ $ xa '
 
 `CONTAINS`関数は含有演算子`@`を関数の形式で呼び出すためのシンタックスシュガーです。
 
-`CONTAINS(container; content)`および`container::CONTAINS(content)`は`content @ container`と等価です。
+`CONTAINS(container; content)`、`container::CONTAINS(content)`、および中置呼び出しの`container CONTAINS content`は`content @ container`と等価です。
 
 ```shell
 $ xa ' CONTAINS("abcde"; "bcd") '
 # TRUE
 
 $ xa ' "abcde"::CONTAINS("bcd") '
+# TRUE
+
+$ xa ' "abcde" CONTAINS "bcd" '
 # TRUE
 ```

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/LangMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/LangMounts.kt
@@ -181,12 +181,20 @@ fun createLangMounts(): List<Map<String, Mount>> {
                 ),
             )
         },
-        "::CONTAINS" define fluoriteArrayOf(
-            FluoriteValue.fluoriteClass colon FluoriteFunction.immediate { arguments ->
-                if (arguments.size != 2) usage("VALUE::CONTAINS(content: VALUE): BOOLEAN")
-                arguments[0].contains(null, arguments[1])
-            },
-        ),
+        *run {
+            fun create(signature: String): FluoriteValue {
+                return FluoriteFunction.immediate { arguments ->
+                    if (arguments.size != 2) usage(signature)
+                    arguments[0].contains(null, arguments[1])
+                }
+            }
+            arrayOf(
+                "CONTAINS" define create("CONTAINS(container: VALUE; content: VALUE): BOOLEAN"),
+                "::CONTAINS" define fluoriteArrayOf(
+                    FluoriteValue.fluoriteClass colon create("VALUE::CONTAINS(content: VALUE): BOOLEAN"),
+                ),
+            )
+        },
         "LAZY" define FluoriteFunction.immediate { arguments ->
             if (arguments.size != 1) usage("<T> LAZY(initializer: () -> T): () -> T")
             val initializer = arguments[0]

--- a/src/commonTest/kotlin/XarpiteTest.kt
+++ b/src/commonTest/kotlin/XarpiteTest.kt
@@ -747,6 +747,18 @@ class XarpiteTest {
         assertEquals(true, eval("'abc' @ {`_@_`: this, value -> value @ '---abc---'}{}").boolean)
         assertEquals(false, eval("'123' @ {`_@_`: this, value -> value @ '---abc---'}{}").boolean)
 
+        // CONTAINS関数で含有チェックができる
+        assertEquals(true, eval("CONTAINS('---abc---'; 'abc')").boolean)
+        assertEquals(false, eval("CONTAINS('---abc---'; '123')").boolean)
+        assertEquals(true, eval("CONTAINS([10, 20, 30]; 30)").boolean)
+        assertEquals(false, eval("CONTAINS([10, 20, 30]; 40)").boolean)
+        assertEquals(true, eval("CONTAINS({a: 10; b: 20}; 'a')").boolean)
+        assertEquals(false, eval("CONTAINS({a: 10; b: 20}; 'c')").boolean)
+
+        // CONTAINS関数はカスタム_@_メソッドでも動作する
+        assertEquals(true, eval("CONTAINS({`_@_`: this, value -> value @ '---abc---'}{}; 'abc')").boolean)
+        assertEquals(false, eval("CONTAINS({`_@_`: this, value -> value @ '---abc---'}{}; '123')").boolean)
+
         // ::CONTAINS拡張関数で含有チェックができる
         assertEquals(true, eval("'---abc---'::CONTAINS('abc')").boolean)
         assertEquals(false, eval("'---abc---'::CONTAINS('123')").boolean)


### PR DESCRIPTION
## 概要

含有演算子 `@` を通常の関数の形式で呼び出すための `CONTAINS` 関数を追加するのだ。

これまで `@` 演算子の関数版は拡張関数 `::CONTAINS` のみが提供されていて、通常関数版が存在しなかったのだ。`ALSO`・`LET`・`RESOLVE` など多くの関数が通常版と拡張関数版の両方を持つ慣例に合わせ、`CONTAINS` の通常関数版を追加するのだ。

議論の文脈は https://github.com/MirrgieRiana/xarpite/pull/686#issuecomment-4887703956 を参照するのだ。

## 仕様

`CONTAINS` 関数は、含有演算子 `@` を関数の形式で呼び出すためのシンタックスシュガーなのだ。

`CONTAINS(container: VALUE; content: VALUE): BOOLEAN`

`CONTAINS(container; content)` は `content @ container` と等価なのだ。既存の拡張関数版 `container::CONTAINS(content)` と同じ結果を返すのだ。

```shell
$ xa ' CONTAINS("abcde"; "bcd") '
# TRUE
```

## 変更点

- `LangMounts.kt` の `::CONTAINS` を、通常版と拡張版で実装を共有する形へ整理し、`CONTAINS` を追加
- `XarpiteTest.kt` に `CONTAINS` のテストを追加
- `pages/docs/{ja,en}/comparison.md` の「比較系関数」節を `CONTAINS` 主体へ再構成
- CHANGELOG 断片を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
