### PR TITLE
instanceOf 演算子の否定版 `!?=` を追加するのだ

### DIFF
--- a/changelog.d/not-instance-of-operator.md
+++ b/changelog.d/not-instance-of-operator.md
@@ -1,0 +1,1 @@
+Added the `!?=` operator that returns whether the left value is not an instance of the right value.

--- a/pages/docs/en/comparison.md
+++ b/pages/docs/en/comparison.md
@@ -31,7 +31,7 @@ $ xa '3 <= 10 <= 5'
 
 The following operators follow this specification:
 
-- `>` `<` `>=` `<=` `==` `!=` `@` `!@` `?=`
+- `>` `<` `>=` `<=` `==` `!=` `@` `!@` `?=` `!?=`
 
 # Comparison Operators
 
@@ -158,7 +158,9 @@ $ xa -q '
 # apple is in basket
 ```
 
-# InstanceOf Operator
+# InstanceOf Operators
+
+## InstanceOf Operator
 
 The instanceOf operator `left ?= right` returns whether `left` is an instance of `right`.
 
@@ -195,6 +197,26 @@ $ xa -q '
 # Human is Animal
 # Socrates is Human
 # Socrates is Animal
+```
+
+## Negative InstanceOf Operator
+
+The negative instanceOf operator `left !?= right` returns whether `left` is not an instance of `right`.
+
+It behaves equivalently to the expression `!(left ?= right)` using the instanceOf operator.
+
+```shell
+$ xa -q '
+  Animal := {}
+  Human := Animal {}
+  Dog := Animal {}
+  socrates := Human{}
+
+  socrates !?= Animal && (OUT << "Socrates is not Animal")
+  socrates !?= Human && (OUT << "Socrates is not Human")
+  socrates !?= Dog && (OUT << "Socrates is not Dog")
+'
+# Socrates is not Dog
 ```
 
 # Spaceship Operator

--- a/pages/docs/ja/comparison.md
+++ b/pages/docs/ja/comparison.md
@@ -31,7 +31,7 @@ $ xa '3 <= 10 <= 5'
 
 この仕様の対象となるのは、以下の演算子です。
 
-- `>` `<` `>=` `<=` `==` `!=` `@` `!@` `?=`
+- `>` `<` `>=` `<=` `==` `!=` `@` `!@` `?=` `!?=`
 
 # 比較演算子
 
@@ -158,7 +158,9 @@ $ xa -q '
 # apple is in basket
 ```
 
-# instanceOf演算子
+# instanceOf系演算子
+
+## instanceOf演算子
 
 instanceOf演算子`left ?= right`は、`left`が`right`のインスタンスであるか否かを返します。
 
@@ -195,6 +197,26 @@ $ xa -q '
 # Human is Animal
 # Socrates is Human
 # Socrates is Animal
+```
+
+## 否定instanceOf演算子
+
+否定instanceOf演算子`left !?= right`は、`left`が`right`のインスタンスでないか否かを返します。
+
+instanceOf演算子を使った`!(left ?= right)`という表現と等価な動作をします。
+
+```shell
+$ xa -q '
+  Animal := {}
+  Human := Animal {}
+  Dog := Animal {}
+  socrates := Human{}
+
+  socrates !?= Animal && (OUT << "Socrates is not Animal")
+  socrates !?= Human && (OUT << "Socrates is not Human")
+  socrates !?= Dog && (OUT << "Socrates is not Dog")
+'
+# Socrates is not Dog
 ```
 
 # 宇宙船演算子

--- a/src/commonMain/kotlin/mirrg/xarpite/Grammar.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Grammar.kt
@@ -272,6 +272,7 @@ class XarpiteGrammar(val location: String, val apiVersion: Int) {
         -"<=" map { ComparisonOperatorType.LESS_EQUAL }, // <=
         -'<' * !'<' map { ComparisonOperatorType.LESS }, // <
         -"?=" map { ComparisonOperatorType.QUESTION_EQUAL }, // ?=
+        -"!?=" map { ComparisonOperatorType.EXCLAMATION_QUESTION_EQUAL }, // !?=
         -"!@" map { ComparisonOperatorType.EXCLAMATION_AT }, // !@
         -'@' map { ComparisonOperatorType.AT }, // @
     )

--- a/src/commonMain/kotlin/mirrg/xarpite/Nodes.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Nodes.kt
@@ -104,6 +104,7 @@ enum class ComparisonOperatorType {
     GREATER_EQUAL,
     LESS_EQUAL,
     QUESTION_EQUAL,
+    EXCLAMATION_QUESTION_EQUAL,
     AT,
     EXCLAMATION_AT,
 }

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/GetterCompiler.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/GetterCompiler.kt
@@ -139,6 +139,7 @@ import mirrg.xarpite.operations.NewEnvironmentGetter
 import mirrg.xarpite.operations.NotContainsComparator
 import mirrg.xarpite.operations.NotDivisibleGetter
 import mirrg.xarpite.operations.NotEqualComparator
+import mirrg.xarpite.operations.NotInstanceOfComparator
 import mirrg.xarpite.operations.NotMatchGetter
 import mirrg.xarpite.operations.NullGetter
 import mirrg.xarpite.operations.ObjectCreationGetter
@@ -301,6 +302,7 @@ fun Frame.compileToGetter(node: Node): Getter {
                     ComparisonOperatorType.GREATER_EQUAL -> GreaterEqualComparator(it.second)
                     ComparisonOperatorType.LESS_EQUAL -> LessEqualComparator(it.second)
                     ComparisonOperatorType.QUESTION_EQUAL -> InstanceOfComparator(it.second)
+                    ComparisonOperatorType.EXCLAMATION_QUESTION_EQUAL -> NotInstanceOfComparator(it.second)
                     ComparisonOperatorType.AT -> ContainsComparator(it.second)
                     ComparisonOperatorType.EXCLAMATION_AT -> NotContainsComparator(it.second)
                 }

--- a/src/commonMain/kotlin/mirrg/xarpite/operations/Comparators.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/operations/Comparators.kt
@@ -44,6 +44,11 @@ class InstanceOfComparator(private val position: Position) : Comparator {
     override val code get() = "InstanceOfComparator"
 }
 
+class NotInstanceOfComparator(private val position: Position) : Comparator {
+    override suspend fun evaluate(env: Environment): suspend (FluoriteValue, FluoriteValue) -> Boolean = { a, b -> !a.instanceOf(b) }
+    override val code get() = "NotInstanceOfComparator"
+}
+
 class ContainsComparator(private val position: Position) : Comparator {
     override suspend fun evaluate(env: Environment): suspend (FluoriteValue, FluoriteValue) -> Boolean = { a, b -> b.contains(position, a).value }
     override val code get() = "ContainsComparator"

--- a/src/commonTest/kotlin/XarpiteTest.kt
+++ b/src/commonTest/kotlin/XarpiteTest.kt
@@ -780,6 +780,24 @@ class XarpiteTest {
     }
 
     @Test
+    fun notInstanceOfTest() = runTest {
+        // 継承チェーンに存在するクラスに対しては FALSE を返す
+        assertEquals(false, eval("A := {}; a := A {}; a !?= A").boolean)
+        assertEquals(false, eval("A := {}; B := A {}; b := B {}; b !?= A").boolean)
+
+        // 無関係なクラスに対しては TRUE を返す
+        assertEquals(true, eval("A := {}; B := {}; a := A {}; a !?= B").boolean)
+
+        // 組み込みクラスに対しても動作する
+        assertEquals(false, eval("1 !?= INT").boolean)
+        assertEquals(true, eval("'10' !?= INT").boolean)
+
+        // !(left ?= right) と等価であることを確認
+        assertEquals(true, eval("!(1 ?= INT) == (1 !?= INT)").boolean)
+        assertEquals(true, eval("!('10' ?= INT) == ('10' !?= INT)").boolean)
+    }
+
+    @Test
     fun andOrTest() = runTest {
         // && は左辺がTRUEの場合に右辺を、 || は左辺がFALSEの場合に右辺を返す
         assertEquals(0, eval("0 && 2").int)


### PR DESCRIPTION
## 概要

instanceOf 演算子 `?=` の否定版 `!?=` を追加するのだ。これまで `left` が `right` のインスタンスでないことを表すには `!(left ?= right)` と書く必要があったのだ。

議論の文脈は Issue #648 を参照するのだ。文法衝突がないこと・破壊的変更にならないことの検証は https://github.com/MirrgieRiana/xarpite/issues/648#issuecomment-4887804595 で示された証明と実機照合に沿っているのだ。

## 仕様

`left !?= right` は、`left` が `right` のインスタンスでないか否かを返すのだ。instanceOf 演算子を使った `!(left ?= right)` という表現と等価に動くのだ。

比較系演算子の階層（`==` や `!@` と同じ `comparisonOperator`）に属し、他の比較系演算子と連鎖できるのだ。

| 式 | 結果 |
| --- | --- |
| `1 !?= INT` | `FALSE` |
| `'10' !?= INT` | `TRUE` |

## 衝突と破壊的変更について

既存のキャッチ演算子 `!?`（`try !? catch`）と字面が似ているが、衝突しないのだ。現状の文法では、コード位置に連続した `!?=` を消費できる規則が存在せず、`a !?= b` は常に構文エラーだったのだ。したがって `!?=` の追加は、これまで構文エラーだった入力を新たに受理するだけで、既存の有効なプログラムのパースを一つも変えず、破壊的変更にはならないのだ。詳細な証明は上記のコメントを参照するのだ。

既存の否定含有演算子 `!@`（`NotContainsComparator`）と同じパターンで、`NotInstanceOfComparator` を追加する小さな変更なのだ。

Closes #648
