### PR TITLE
STRING メソッド `trim` `trimStart` `trimEnd` を追加するのだ

### DIFF
--- a/changelog.d/string-trim.md
+++ b/changelog.d/string-trim.md
@@ -1,0 +1,1 @@
+Added STRING methods `trim`, `trimStart`, and `trimEnd` that remove whitespace from the ends of a string.

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -436,13 +436,13 @@ Returns the string with the whitespace removed from the beginning and end of the
 The whitespace to be removed includes spaces, tabs, and newlines, as well as Unicode whitespace characters such as the ideographic space.
 
 ```shell
-$ xa '"[" & "  abc  "::trim() & "]"'
+$ xa '"[$(  "  abc  "::trim()  )]"'
 # [abc]
 
-$ xa '"[" & "  abc  "::trimStart() & "]"'
+$ xa '"[$(  "  abc  "::trimStart()  )]"'
 # [abc  ]
 
-$ xa '"[" & "  abc  "::trimEnd() & "]"'
+$ xa '"[$(  "  abc  "::trimEnd()  )]"'
 # [  abc]
 ```
 

--- a/pages/docs/en/string.md
+++ b/pages/docs/en/string.md
@@ -421,6 +421,31 @@ $ xa '"[" & "abcde"::drop(10) & "]"'
 # []
 ```
 
+# Removing Whitespace from the Ends
+
+`STRING::trim(): STRING`
+
+`STRING::trimStart(): STRING`
+
+`STRING::trimEnd(): STRING`
+
+Returns the string with the whitespace removed from the beginning and end of the string.
+
+`trim` removes whitespace from both ends, `trimStart` from the beginning, and `trimEnd` from the end.
+
+The whitespace to be removed includes spaces, tabs, and newlines, as well as Unicode whitespace characters such as the ideographic space.
+
+```shell
+$ xa '"[" & "  abc  "::trim() & "]"'
+# [abc]
+
+$ xa '"[" & "  abc  "::trimStart() & "]"'
+# [abc  ]
+
+$ xa '"[" & "  abc  "::trimEnd() & "]"'
+# [  abc]
+```
+
 # Taking Characters from the Ends
 
 `STRING::first(): STRING | NULL`

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -421,6 +421,31 @@ $ xa '"[" & "abcde"::drop(10) & "]"'
 # []
 ```
 
+# 先頭・末尾の空白の除去
+
+`STRING::trim(): STRING`
+
+`STRING::trimStart(): STRING`
+
+`STRING::trimEnd(): STRING`
+
+文字列の先頭および末尾の空白を除去した文字列を返します。
+
+`trim`は両端、`trimStart`は先頭、`trimEnd`は末尾の空白を除去します。
+
+除去の対象となる空白は、半角スペースやタブ、改行のほか、全角空白などのUnicodeの空白文字を含みます。
+
+```shell
+$ xa '"[" & "  abc  "::trim() & "]"'
+# [abc]
+
+$ xa '"[" & "  abc  "::trimStart() & "]"'
+# [abc  ]
+
+$ xa '"[" & "  abc  "::trimEnd() & "]"'
+# [  abc]
+```
+
 # 先頭・末尾の文字の取得
 
 `STRING::first(): STRING | NULL`

--- a/pages/docs/ja/string.md
+++ b/pages/docs/ja/string.md
@@ -436,13 +436,13 @@ $ xa '"[" & "abcde"::drop(10) & "]"'
 除去の対象となる空白は、半角スペースやタブ、改行のほか、全角空白などのUnicodeの空白文字を含みます。
 
 ```shell
-$ xa '"[" & "  abc  "::trim() & "]"'
+$ xa '"[$(  "  abc  "::trim()  )]"'
 # [abc]
 
-$ xa '"[" & "  abc  "::trimStart() & "]"'
+$ xa '"[$(  "  abc  "::trimStart()  )]"'
 # [abc  ]
 
-$ xa '"[" & "  abc  "::trimEnd() & "]"'
+$ xa '"[$(  "  abc  "::trimEnd()  )]"'
 # [  abc]
 ```
 

--- a/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/compilers/objects/FluoriteString.kt
@@ -134,6 +134,20 @@ data class FluoriteString(val value: String) : FluoriteValue {
                             "dropLast" to create("dropLast") { string, count -> string.dropLast(count) },
                         )
                     },
+                    *run {
+                        fun create(name: String, transform: (String) -> String): FluoriteValue {
+                            return FluoriteFunction.immediate { arguments ->
+                                if (arguments.size != 1) throw IllegalArgumentException("STRING::$name(): STRING")
+                                val string = arguments[0] as FluoriteString
+                                transform(string.value).toFluoriteString()
+                            }
+                        }
+                        arrayOf(
+                            "trim" to create("trim") { it.trim() },
+                            "trimStart" to create("trimStart") { it.trimStart() },
+                            "trimEnd" to create("trimEnd") { it.trimEnd() },
+                        )
+                    },
                     "first" to FluoriteFunction.immediate { arguments ->
                         if (arguments.size != 1) throw IllegalArgumentException("STRING::first(): STRING | NULL")
                         val string = arguments[0] as FluoriteString

--- a/src/commonTest/kotlin/StringTest.kt
+++ b/src/commonTest/kotlin/StringTest.kt
@@ -89,6 +89,8 @@ class StringTest {
         assertEquals("abc  ", eval("'  abc  '::trimStart()").string) // 先頭の空白のみを除去し、末尾は保持する
         assertEquals("abc　　", eval("'　　abc　　'::trimStart()").string) // 全角空白も先頭のみ除去される
         assertEquals("", eval("'   '::trimStart()").string) // 空白のみの文字列は空文字列になる
+        assertEquals("", eval("''::trimStart()").string) // 空文字列はそのまま空文字列になる
+        assertEquals("abc", eval("'abc'::trimStart()").string) // 先頭に空白が無ければそのまま返る
     }
 
     @Test
@@ -96,6 +98,8 @@ class StringTest {
         assertEquals("  abc", eval("'  abc  '::trimEnd()").string) // 末尾の空白のみを除去し、先頭は保持する
         assertEquals("　　abc", eval("'　　abc　　'::trimEnd()").string) // 全角空白も末尾のみ除去される
         assertEquals("", eval("'   '::trimEnd()").string) // 空白のみの文字列は空文字列になる
+        assertEquals("", eval("''::trimEnd()").string) // 空文字列はそのまま空文字列になる
+        assertEquals("abc", eval("'abc'::trimEnd()").string) // 末尾に空白が無ければそのまま返る
     }
 
     @Test

--- a/src/commonTest/kotlin/StringTest.kt
+++ b/src/commonTest/kotlin/StringTest.kt
@@ -74,6 +74,31 @@ class StringTest {
     }
 
     @Test
+    fun trim() = runTest {
+        assertEquals("abc", eval("'  abc  '::trim()").string) // 前後の半角スペースを除去する
+        assertEquals("abc", eval("' \tabc\n '::trim()").string) // タブや改行も除去する
+        assertEquals("abc", eval("'　　abc　　'::trim()").string) // 全角空白 U+3000 も Unicode 空白として除去される
+        assertEquals("a b c", eval("'  a b c  '::trim()").string) // 内側の空白は保持される
+        assertEquals("", eval("'　 \t\n '::trim()").string) // 空白のみの文字列は空文字列になる
+        assertEquals("", eval("''::trim()").string) // 空文字列はそのまま空文字列になる
+        assertEquals("abc", eval("'abc'::trim()").string) // 前後に空白が無ければそのまま返る
+    }
+
+    @Test
+    fun trimStart() = runTest {
+        assertEquals("abc  ", eval("'  abc  '::trimStart()").string) // 先頭の空白のみを除去し、末尾は保持する
+        assertEquals("abc　　", eval("'　　abc　　'::trimStart()").string) // 全角空白も先頭のみ除去される
+        assertEquals("", eval("'   '::trimStart()").string) // 空白のみの文字列は空文字列になる
+    }
+
+    @Test
+    fun trimEnd() = runTest {
+        assertEquals("  abc", eval("'  abc  '::trimEnd()").string) // 末尾の空白のみを除去し、先頭は保持する
+        assertEquals("　　abc", eval("'　　abc　　'::trimEnd()").string) // 全角空白も末尾のみ除去される
+        assertEquals("", eval("'   '::trimEnd()").string) // 空白のみの文字列は空文字列になる
+    }
+
+    @Test
     fun firstAndLast() = runTest {
         assertEquals("a", eval("'abc'::first()").string) // 先頭の 1 文字を取得する
         assertEquals("c", eval("'abc'::last()").string) // 末尾の 1 文字を取得する


### PR DESCRIPTION
## 概要

文字列の先頭・末尾の空白を除去する STRING メソッド `trim` / `trimStart` / `trimEnd` を追加するのだ。

`trim`は両端、`trimStart`は先頭、`trimEnd`は末尾の空白を除去するのだ。

Issue #682 の議論を受けての実装なのだ。空白の扱いは https://github.com/MirrgieRiana/xarpite/issues/682#issuecomment-4894623307 の「Kotlin の仕様に従う」という決定に基づいて、Kotlin の `String.trim()` に合わせているのだ。

Closes #682

## 仕様

除去の対象となる空白は、Kotlin の `String.trim()` / `trimStart()` / `trimEnd()`（`Char::isWhitespace` 基準）に従うのだ。半角スペース・タブ・改行のほか、全角空白 U+3000 などの Unicode の空白文字も除去されるのだ。

| メソッド      | 対象 |
|-------------|----|
| `trim`      | 両端 |
| `trimStart` | 先頭 |
| `trimEnd`   | 末尾 |

いずれも引数を取らず、破壊的変更を含まない純粋な機能追加なのだ。

## 動作例

```
$ xa '"[" & "  abc  "::trim() & "]"'
# [abc]

$ xa '"[" & "  abc  "::trimStart() & "]"'
# [abc  ]

$ xa '"[" & "  abc  "::trimEnd() & "]"'
# [  abc]
```
