### PR TITLE
YAML の入出力を行う `YAML` `YAMLD` 関数を追加するのだ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
                 implementation("com.squareup.okio:okio:3.10.2")
                 implementation("com.ionspin.kotlin:bignum:0.3.10")
+                implementation("it.krzeminski:snakeyaml-engine-kmp:4.0.1")
                 implementation("mirrg.kotlin:mirrg.kotlin.helium-kotlin-2-2:4.4.0")
                 implementation("io.github.mirrgieriana:xarpeg:6.2.0")
                 implementation("io.ktor:ktor-client-core:3.4.0")

--- a/changelog.d/add-yaml-functions.md
+++ b/changelog.d/add-yaml-functions.md
@@ -1,0 +1,2 @@
+Added `YAML` function that converts a value into a YAML string.
+Added `YAMLD` function that converts a YAML string into the corresponding value.

--- a/pages/docs/en/data-conversion.md
+++ b/pages/docs/en/data-conversion.md
@@ -402,6 +402,31 @@ $ xa '
 # {b:2}
 ```
 
+## `YAML` Convert Value to YAML String
+
+`YAML(value: VALUE): STRING`
+
+Converts `value` to a YAML-formatted string.
+
+```shell
+$ xa '{a: 1; b: 2} >> YAML'
+# a: 1
+# b: 2
+```
+
+## `YAMLD` Convert YAML String to Value
+
+`YAMLD(yaml: STRING): VALUE`
+
+Converts `yaml` to the corresponding value.
+
+```shell
+$ xa ' "{a: 1, b: 2}" >> YAMLD '
+# {a:1;b:2}
+```
+
+If you pass a YAML containing multiple documents, an error occurs.
+
 ## `CSV` Convert Array to CSV String
 
 `CSV([separator: separator: STRING; ][quote: quote: STRING; ]value: STREAM<ARRAY<STRING>>): STREAM<STRING>`

--- a/pages/docs/ja/data-conversion.md
+++ b/pages/docs/ja/data-conversion.md
@@ -402,6 +402,31 @@ $ xa '
 # {b:2}
 ```
 
+## `YAML`値をYAML文字列に変換
+
+`YAML(value: VALUE): STRING`
+
+`value`をYAML形式の文字列に変換します。
+
+```shell
+$ xa '{a: 1; b: 2} >> YAML'
+# a: 1
+# b: 2
+```
+
+## `YAMLD` YAML文字列を値に変換
+
+`YAMLD(yaml: STRING): VALUE`
+
+`yaml`を対応する値に変換します。
+
+```shell
+$ xa ' "{a: 1, b: 2}" >> YAMLD '
+# {a:1;b:2}
+```
+
+複数のドキュメントを含むYAMLを与えた場合、エラーになります。
+
 ## `CSV`配列をCSV文字列に変換
 
 `CSV([separator: separator: STRING; ][quote: quote: STRING; ]value: STREAM<ARRAY<STRING>>): STREAM<STRING>`

--- a/src/commonMain/kotlin/mirrg/xarpite/Util.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/Util.kt
@@ -1,5 +1,21 @@
 package mirrg.xarpite
 
+import it.krzeminski.snakeyaml.engine.kmp.api.ConstructNode
+import it.krzeminski.snakeyaml.engine.kmp.api.Dump
+import it.krzeminski.snakeyaml.engine.kmp.api.DumpSettings
+import it.krzeminski.snakeyaml.engine.kmp.api.Load
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+import it.krzeminski.snakeyaml.engine.kmp.api.StreamDataWriter
+import it.krzeminski.snakeyaml.engine.kmp.api.copy
+import it.krzeminski.snakeyaml.engine.kmp.common.FlowStyle
+import it.krzeminski.snakeyaml.engine.kmp.common.ScalarStyle
+import it.krzeminski.snakeyaml.engine.kmp.exceptions.YamlEngineException
+import it.krzeminski.snakeyaml.engine.kmp.nodes.MappingNode
+import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
+import it.krzeminski.snakeyaml.engine.kmp.nodes.NodeTuple
+import it.krzeminski.snakeyaml.engine.kmp.nodes.ScalarNode
+import it.krzeminski.snakeyaml.engine.kmp.nodes.SequenceNode
+import it.krzeminski.snakeyaml.engine.kmp.nodes.Tag
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -187,6 +203,105 @@ suspend fun FluoriteValue.toFluoriteValueAsJsons(position: Position?): FluoriteV
         }
     }
 }
+
+
+private val yamlDumpSettings by lazy { DumpSettings().copy { defaultFlowStyle = FlowStyle.BLOCK } }
+
+private class YamlStringWriter : StreamDataWriter {
+    private val sb = StringBuilder()
+    override fun write(str: String) {
+        sb.append(str)
+    }
+
+    override fun write(str: String, off: Int, len: Int) {
+        sb.append(str, off, off + len)
+    }
+
+    override fun toString() = sb.toString()
+}
+
+/**
+ * 非数と無限大は、KotlinとYAMLで表記が異なります。
+ */
+private fun Double.toYamlFloat(): String = when {
+    this.isNaN() -> ".nan"
+    this == Double.POSITIVE_INFINITY -> ".inf"
+    this == Double.NEGATIVE_INFINITY -> "-.inf"
+    else -> this.toString()
+}
+
+suspend fun FluoriteValue.toSingleYaml(position: Position?): String {
+    suspend fun FluoriteValue.toYamlNode(): Node = when (this) {
+        is FluoriteObject -> MappingNode(Tag.MAP, this.map.map { NodeTuple(ScalarNode(Tag.STR, it.key, ScalarStyle.PLAIN), it.value.toYamlNode()) }, FlowStyle.BLOCK)
+        is FluoriteArray -> SequenceNode(Tag.SEQ, this.values.map { it.toYamlNode() }, FlowStyle.BLOCK)
+        is FluoriteInt -> ScalarNode(Tag.INT, this.value.toString(), ScalarStyle.PLAIN)
+        is FluoriteBig -> ScalarNode(Tag.INT, this.value.toString(), ScalarStyle.PLAIN)
+        is FluoriteDouble -> ScalarNode(Tag.FLOAT, this.value.toYamlFloat(), ScalarStyle.PLAIN)
+        is FluoriteString -> ScalarNode(Tag.STR, this.value, ScalarStyle.PLAIN)
+        is FluoriteBoolean -> ScalarNode(Tag.BOOL, this.value.toString(), ScalarStyle.PLAIN)
+        FluoriteNull -> ScalarNode(Tag.NULL, "null", ScalarStyle.PLAIN)
+        is FluoriteStream -> throw IllegalArgumentException("Cannot convert FluoriteStream to single YAML")
+        else -> this.callMethod(position, "$&_").toYamlNode() // JSONと同じ変換フックを利用します
+    }
+
+    val node = this.toYamlNode()
+    val writer = YamlStringWriter()
+    try {
+        Dump(yamlDumpSettings).dumpNode(node, writer)
+    } catch (e: YamlEngineException) {
+        throw FluoriteException("Failed to encode to YAML: ${e.message ?: e.toString()}".toFluoriteString())
+    }
+    return writer.toString().removeSuffix("\n") // YAMLの出力は必ず改行で終わるため、他の変換関数と揃えます
+}
+
+suspend fun FluoriteValue.toSingleYamlFluoriteValue(position: Position?) = this.toSingleYaml(position).toFluoriteString()
+
+
+private class YamlInt(val text: String)
+
+/**
+ * Kotlin/JSとネイティブのsnakeyaml-engine-kmpは任意精度整数を実装していないため、整数の構築を自前で行います。
+ * 桁数の制限を受けずに整数を扱うため、10進数の表記は文字列のまま持ち回ります。
+ */
+private object YamlIntConstructor : ConstructNode {
+    override fun construct(node: Node?): YamlInt {
+        val text = (node as ScalarNode).value
+        return YamlInt(
+            when {
+                text.startsWith("0x") -> text.drop(2).toLong(16).toString()
+                text.startsWith("0o") -> text.drop(2).toLong(8).toString()
+                else -> text
+            }
+        )
+    }
+}
+
+private val yamlLoadSettings by lazy { LoadSettings().copy { tagConstructors = mapOf(Tag.INT to YamlIntConstructor) } }
+
+fun String.toFluoriteValueAsSingleYaml(): FluoriteValue {
+    fun Any?.toFluoriteValue(): FluoriteValue = when (this) {
+        null -> FluoriteNull
+        is Map<*, *> -> FluoriteObject(FluoriteObject.fluoriteClass, this.entries.associate { it.key.toString() to it.value.toFluoriteValue() }.toMutableMap())
+        is Iterable<*> -> this.map { it.toFluoriteValue() }.toFluoriteArray()
+        is String -> this.toFluoriteString()
+        is Boolean -> if (this) FluoriteBoolean.TRUE else FluoriteBoolean.FALSE
+        is YamlInt -> this.text.toFluoriteNumber()
+        is Double -> FluoriteDouble(this)
+        is Number -> this.toString().toFluoriteNumber()
+        else -> throw FluoriteException("Unsupported YAML value: ${this::class.simpleName}".toFluoriteString())
+    }
+
+    val value = try {
+        Load(yamlLoadSettings).loadOne(this)
+    } catch (e: YamlEngineException) {
+        throw FluoriteException("Invalid YAML: ${e.message ?: e.toString()}".toFluoriteString())
+    } catch (e: NumberFormatException) {
+        throw FluoriteException("Invalid YAML: ${e.message ?: e.toString()}".toFluoriteString())
+    }
+    return value.toFluoriteValue()
+}
+
+suspend fun FluoriteValue.toFluoriteValueAsSingleYaml(position: Position?) = this.toFluoriteString(position).value.toFluoriteValueAsSingleYaml()
 
 
 /**

--- a/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
+++ b/src/commonMain/kotlin/mirrg/xarpite/mounts/DataConversionMounts.kt
@@ -23,8 +23,10 @@ import mirrg.xarpite.partitionIfEntry
 import mirrg.xarpite.pop
 import mirrg.xarpite.toFluoriteValueAsJsons
 import mirrg.xarpite.toFluoriteValueAsSingleJson
+import mirrg.xarpite.toFluoriteValueAsSingleYaml
 import mirrg.xarpite.toJsonsFluoriteValue
 import mirrg.xarpite.toSingleJsonFluoriteValue
+import mirrg.xarpite.toSingleYamlFluoriteValue
 import okio.Buffer
 import kotlin.io.encoding.Base64
 
@@ -264,6 +266,18 @@ fun createDataConversionMounts(): List<Map<String, Mount>> {
                     )
                 },
             )
+        },
+        "YAML" define FluoriteFunction.immediate { arguments ->
+            fun usage(): Nothing = usage("YAML(value: VALUE): STRING")
+            if (arguments.size != 1) usage()
+            val value = arguments[0]
+            value.toSingleYamlFluoriteValue(null)
+        },
+        "YAMLD" define FluoriteFunction.immediate { arguments ->
+            fun usage(): Nothing = usage("YAMLD(yaml: STRING): VALUE")
+            if (arguments.size != 1) usage()
+            val value = arguments[0]
+            value.toFluoriteValueAsSingleYaml(null)
         },
         *run {
             fun create(name: String, defaultSeparator: String): FluoriteFunction {

--- a/src/commonTest/kotlin/DataConversionTest.kt
+++ b/src/commonTest/kotlin/DataConversionTest.kt
@@ -117,6 +117,31 @@ class DataConversionTest {
     }
 
     @Test
+    fun yamlFunction() = runTest {
+        // YAML
+        assertEquals("a:\n- 1\n- 2.5\n- '3'\n- true\n- false\n- null", eval(""" {a: [1, 2.5, "3", TRUE, FALSE, NULL]} >> YAML """).string) // YAML で値をYaml文字列に変換する
+        assertEquals("1", eval("1 >> YAML").string) // プリミティブを直接指定できる
+        assertEquals("a: 1\nb:\n  c: 2", eval(""" {a: 1; b: {c: 2}} >> YAML """).string) // 入れ子のオブジェクトはインデントで表現される
+        assertEquals("{}", eval(""" {} >> YAML """).string) // 空のオブジェクトはフロースタイルで出力される
+        assertEquals("[]", eval(""" [] >> YAML """).string) // 空の配列はフロースタイルで出力される
+        assertEquals("'3'", eval(""" "3" >> YAML """).string) // 数値に解釈されうる文字列は引用符で囲まれる
+        assertEquals(".inf", eval(""" (1 / 0) >> YAML """).string) // JSONと異なり、特殊な浮動小数点値も表現できる
+
+        // YAMLD
+        assertEquals("""{a:[1;2.5;3;TRUE;FALSE;NULL]}""", eval(""" "{a: [1, 2.5, '3', true, false, null]}" >> YAMLD """).obj) // YAMLD でYaml文字列を値に変換する
+        assertEquals("""{a:[1;2]}""", eval(""" "a:\n- 1\n- 2" >> YAMLD """).obj) // ブロックスタイルのYamlも解釈できる
+        assertEquals(1, eval(""" "1" >> YAMLD """).int) // プリミティブを直接指定できる
+        assertEquals(31, eval(""" "0x1F" >> YAMLD """).int) // 16進数表記の整数を解釈できる
+        assertEquals(FluoriteNull, eval(""" "" >> YAMLD """)) // 内容が空の場合、NULLになる
+        assertEquals("1718445872123456789", eval(""" "1718445872123456789" >> YAMLD >> YAML """).string) // INTの範囲を超える整数は精度を失わずデコードされる
+        assertEquals("123456789012345678901234567890", eval(""" "123456789012345678901234567890" >> YAMLD >> YAML """).string) // 任意の桁数の整数でも精度が保たれる
+
+        // 不正な入力はネイティブ例外ではなく文字列のエラーになる
+        assertTrue(eval(""" ("a: [1, 2}" >> YAMLD) !? (e => e) """).string.startsWith("Invalid YAML")) // 不正なYAMLのデコードは "Invalid YAML" で始まる文字列のエラーになる
+        assertTrue(eval(""" ("a: 1\n---\nb: 2" >> YAMLD) !? (e => e) """).string.startsWith("Invalid YAML")) // 複数のドキュメントを含むYAMLのデコードは "Invalid YAML" で始まる文字列のエラーになる
+    }
+
+    @Test
     fun csv() = runTest {
         assertEquals("""a,b""", eval(""" ["a","b"] >> CSV """).string) // CSV で配列を文字列に変換できる
         assertEquals("""["a","b"]""", eval(""" "a,b" >> CSVD >> JSON """).string) // CSVD で文字列を配列に変換できる


### PR DESCRIPTION
## 概要

YAML の入出力を行う `YAML` / `YAMLD` 関数を追加するのだ。

Issue #666 の議論を受けての実装なのだ。YAML の処理には https://github.com/MirrgieRiana/xarpite/issues/666#issuecomment-5123897767 で挙げられた snakeyaml-engine-kmp を採用しているのだ。

Refs: https://github.com/MirrgieRiana/xarpite/issues/666

## 仕様

| 関数 | 説明 |
| --- | --- |
| `YAML(value: VALUE): STRING` | 値を YAML 形式の文字列に変換するのだ |
| `YAMLD(yaml: STRING): VALUE` | YAML 形式の文字列を対応する値に変換するのだ |

オブジェクトと配列はブロックスタイルで出力するのだ。ただし、要素を持たないものは `{}` `[]` になるのだ。

出力の末尾には改行を付けないのだ。YAML の直列化は必ず改行で終わるけれど、`JSON` 関数などの他の変換関数と揃えるために、末尾の1個を取り除いているのだ。

`YAMLD` に複数のドキュメントを含む YAML を与えた場合は、エラーになるのだ。

## 動作例

```
$ xa '{a: 1; b: 2} >> YAML'
# a: 1
# b: 2

$ xa ' "{a: 1, b: 2}" >> YAMLD '
# {a:1;b:2}

$ xa ' "0x1F" >> YAMLD '
# 31
```

## 実装上の判断

### snakeyaml-engine-kmp の対応プラットフォーム

`it.krzeminski:snakeyaml-engine-kmp` の 4.0.1 には jvm / js / linuxx64 の成果物がそろっていて、Xarpite の全ターゲットで使えるのだ。

このライブラリは okio 3.16.0 を要求するから、Xarpite が直接指定している okio 3.10.2 より新しい方が選ばれることになるのだ。

### エンコードの経路

`Dump.dumpToString` に Kotlin の値を渡す形ではなく、`Node` を自分で組み立てて `Dump.dumpNode` に渡す形にしているのだ。オブジェクトのキーの順序を保ちたかったのと、`BIG` の任意精度整数を引用符なしの数値として出力したかったのが理由なのだ。

`INT` の範囲を超える整数や、`.inf` `.nan` といった特殊な浮動小数点値も、この経路なら表現できるのだ。`JSON` 関数では特殊な浮動小数点値がエラーになるから、そこは YAML 側だけの利点になるのだ。

### デコードの経路

逆方向は `Load.loadOne` を使っているのだ。16進数表記 `0x1F` や `.inf` `.nan` といった YAML の数値表記の解釈を、ライブラリに委ねられるからなのだ。

### 任意精度整数の扱い

ただし、`Tag.INT` のコンストラクタだけは自前のものに差し替えているのだ。snakeyaml-engine-kmp が JVM 以外のターゲットで任意精度整数を実装しておらず、`An operation is not implemented: Kotlin/JS BigInteger implementation` になってしまうからなのだ。

差し替えた側では、整数を文字列のまま受け取って、Xarpite 側の数値変換に委ねているのだ。これで、どのターゲットでも桁数の制限なく整数を読めるのだ。16進数の `0x` と8進数の `0o` の表記だけは、この経路で自分で解釈しているのだ。

### JSON 変換フックの流用

`YAML` 関数が変換方法を知らない値に対しては、JSON 化のメソッド `$&_` を呼んでいるのだ。JSON にできる値は YAML にもできるのが自然だと考えたからなのだ。YAML 専用のフックを新設する案も、選択肢としてはあるのだ。

## この PR に含めていないこと

YAML の複数ドキュメント（`---` 区切り）の入出力は、この PR には入れていないのだ。`JSONL` / `JSONLD` に相当する位置づけになると思うけれど、関数名の付け方から検討が必要になるから、切り離しているのだ。

インデント幅の指定も入れていないのだ。`JSON` 関数の `indent` に相当するオプションを付けるかどうかは、別に決めた方がよいと思うのだ。

`!!binary` タグの付いた YAML は、`YAMLD` でエラーになるのだ。`BLOB` への対応は、逆方向の出力とあわせて考えることになるから、これも入れていないのだ。

🌱Claude Fairy